### PR TITLE
Support menu UI in a client-specified element without iframe

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -3,7 +3,7 @@ var argv = require('yargs').argv,
     production = !!argv.production,
     buildInfo = argv.buildInfo || 'development build (' + (new Date()) + ')',
     src = './src',
-    dest  = './dist';
+    dest  = argv.dest ? argv.dest : './dist';
 
 module.exports = {
   browserify: {

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -5,7 +5,7 @@ var runSequence = require('run-sequence');
 var config      = require('../config').deploy;
 
 gulp.task('clean', function() {
-    return del([config.src]);
+    return del([config.src], { force: true });
 });
 
 gulp.task('clean-and-build', function(callback) {

--- a/src/assets/examples/index.html
+++ b/src/assets/examples/index.html
@@ -12,6 +12,7 @@
     <ul>
       <li><a href="all-providers.html">All Providers</a></li>
       <li><a href="no-frame.html">No Frame</a></li>
+      <li><a href="view-no-frame.html">View Without Frame</a></li>
       <li><a href="auto-saving.html">Auto Saving</a></li>
       <li><a href="new-does-not-use-new-tab.html">New Does Not Open in New Tab</a></li>
       <li><a href="read-only-with-folders.html">Read Only with Folders</a></li>

--- a/src/assets/examples/view-no-frame.html
+++ b/src/assets/examples/view-no-frame.html
@@ -1,0 +1,126 @@
+<html>
+  <head>
+    <script src="../js/globals.js"></script>
+    <script src="../js/app.js"></script>
+    <link rel="stylesheet" href="../css/app.css">
+    <style>
+      body {
+        font-family: 'Arial', 'Helvetica', 'sans-serif'
+      }
+      textarea {
+        width: 100%;
+        height:300px;
+      }
+      #buttons {
+        margin-top: 10px;
+      }
+    </style>
+    <script type="text/javascript">
+      /* global CloudFileManager */
+      var cfmClient, cfmContent;
+
+      /* exported newFile, openFile, saveFile, saveFileAs, getContent, setContent,
+                  connected, changed, focus */
+      function newFile() {
+        cfmClient && cfmClient.newFileDialog();
+      }
+
+      function openFile() {
+        // no callback for open - we will handle it in the clientInit event callback
+        cfmClient && cfmClient.openFileDialog();
+      }
+
+      function saveFile() {
+        cfmClient && cfmClient.save();
+      }
+
+      function saveFileAs() {
+        cfmClient && cfmClient.saveFileAsDialog(getContent());
+      }
+
+      function getContent() {
+        cfmContent = document.getElementById("text").value;
+        return cfmContent;
+      }
+
+      function setContent(_cfmContent) {
+        cfmContent = _cfmContent;
+        document.getElementById("text").value = cfmContent;
+      }
+
+      function connected(client) {
+        cfmClient = client;
+        cfmContent = document.getElementById("text").value;
+      }
+
+      function changed() {
+        cfmClient.dirty();
+      }
+
+      function focus() {
+        document.getElementById("text").focus();
+      }
+    </script>
+  </head>
+  <body>
+    <h2>Demo App</h2>
+    <p>
+      This simple demo app uses the textarea below to edit text files. You can use
+      the menu bar below to open, save and create new files.
+    </p>
+    <div>
+      <textarea cols="50" rows="10" id="text"></textarea>
+    </div>
+    <!-- CFM menu bar will attach here -->
+    <div id="menuBar"></div>
+    <script type="text/javascript">
+      var clientOptions = {
+        mimeType: "text/plain",
+        appName: "CFM_Demo",
+        appVersion: "0.1",
+        appBuildNum: "1",
+        appOrMenuElemId: "menuBar",
+        providers: [
+          "localStorage",
+          {
+            "name": "readOnly",
+            "json": {
+              "first-example": "This is the first readonly example",
+              "second-example": "This is the second readonly example"
+            }
+          },
+          {
+            "name": "googleDrive",
+            "mimeType": "text/plain",
+            "clientId": "1095918012594-svs72eqfalasuc4t1p1ps1m8r9b8psso.apps.googleusercontent.com"
+          },
+          {
+            "name": "documentStore",
+            "patch": true
+          }
+        ]
+      };
+      CloudFileManager.init(clientOptions);
+      CloudFileManager.clientConnect(function (event) {
+        console.log(event);
+        switch (event.type) {
+          case 'connected':
+            connected(event.data.client);
+            break;
+
+            case 'getContent':
+              event.callback(getContent());
+              break;
+
+            case 'newedFile':
+            case 'openedFile':
+              setContent(event.data.content);
+              focus();
+              break;
+        }
+      });
+
+      document.getElementById("text").focus();
+    </script>
+  </body>
+</html>

--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -31,7 +31,7 @@ class CloudFileManager
     @_renderApp document.getElementById(appElemId)
 
   clientConnect: (eventCallback) ->
-    if !!@appOptions.appOrMenuElemId
+    if @appOptions.appOrMenuElemId?
       @_renderApp document.getElementById(@appOptions.appOrMenuElemId)
     else
       @_createHiddenApp()

--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -14,17 +14,26 @@ class CloudFileManager
     @client = new CloudFileManagerClient()
     @appOptions = {}
 
-  init: (@appOptions, usingIframe = false) ->
-    @appOptions.usingIframe = usingIframe
+  # usingIframe: if true, client app is wrapped in an iframe within the CFM-managed div
+  # appOrMenuElemId: if appOrMenuElemId is passed and usingIframe is true, then the CFM
+  #   presents its UI and the wrapped client app within the specified element. If
+  #   appOrMenuElemId is set and usingIframe is false, then the CFM presents its menubar
+  #   UI within the specified element, but there is no iframe or wrapped client app.
+  init: (@appOptions) ->
     @client.setAppOptions @appOptions
 
-  createFrame: (@appOptions, elemId, eventCallback = null) ->
-    @init @appOptions, true
+  # Convenience function for settinp up CFM with an iframe-wrapped client app
+  createFrame: (@appOptions, appElemId, eventCallback = null) ->
+    @appOptions.usingIframe = true
+    @appOptions.appOrMenuElemId = appElemId
+    @init @appOptions
     @client.listen eventCallback
-    @_renderApp document.getElementById(elemId)
+    @_renderApp document.getElementById(appElemId)
 
   clientConnect: (eventCallback) ->
-    if not @appOptions.usingIframe
+    if !!@appOptions.appOrMenuElemId
+      @_renderApp document.getElementById(@appOptions.appOrMenuElemId)
+    else
       @_createHiddenApp()
     @client.listen eventCallback
     @client.connect()

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -91,10 +91,10 @@ class DocumentStoreProvider extends ProviderInterface
       xhrFields:
         withCredentials: true
       success: (data) ->
-        provider.docStoreLoadedCallback()
+        provider.docStoreLoadedCallback?()
         provider._loginSuccessful(data)
       error: ->
-        provider.docStoreLoadedCallback()
+        provider.docStoreLoadedCallback?()
 
   _loginWindow: null
 

--- a/src/code/ui.coffee
+++ b/src/code/ui.coffee
@@ -10,6 +10,7 @@ class CloudFileManagerUIMenu
   @DefaultMenu: ['newFileDialog', 'openFileDialog', 'revertSubMenu', 'separator', 'save', 'createCopy', 'shareSubMenu', 'downloadDialog', 'renameDialog']
 
   constructor: (options, client) ->
+    @options = options
     @items = @parseMenuItems options.menu, client
 
   parseMenuItems: (menuItems, client) ->
@@ -65,7 +66,7 @@ class CloudFileManagerUIMenu
       else if isString item
         menuItem =
           key: item
-          name: options.menuNames?[item] or names[item] or "Unknown item: #{item}"
+          name: @options.menuNames?[item] or names[item] or "Unknown item: #{item}"
           enabled: setEnabled item
           items: getItems subMenus[item]
           action: setAction item

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -140,10 +140,13 @@ App = React.createClass
       (ShareDialog {client: @props.client, close: @closeDialogs})
 
   render: ->
-    if @props.usingIframe
-      (div {className: 'app'},
+    if @props.appOrMenuElemId
+      # CSS class depends on whether we're in app (iframe) or view (menubar-only) mode
+      (div {className: if @props.usingIframe then 'app' else 'view' },
         (MenuBar {client: @props.client, filename: @state.filename, provider: @state.provider, fileStatus: @state.fileStatus, items: @state.menuItems, options: @state.menuOptions})
-        (InnerApp {app: @props.app})
+        # only render the wrapped client app in app (iframe) mode
+        if @props.usingIframe
+          (InnerApp {app: @props.app})
         @renderDialogs()
       )
     else if @state.providerDialog or @state.downloadDialog

--- a/src/code/views/modal-view.coffee
+++ b/src/code/views/modal-view.coffee
@@ -8,14 +8,28 @@ module.exports = React.createClass
     if e.keyCode is 27
       @props.close?()
 
+  # shadow the entire viewport behind the dialog
+  getDimensions: ->
+    return { width: $(window).width() + 'px', height: $(window).height() + 'px'}
+
+  getInitialState: ->
+    return { dimensions: @getDimensions() }
+
+  # update dimensions in state on resize
+  updateDimensions: ->
+    @setState { dimensions: @getDimensions() }
+
+  # use bind/unbind for clients using older versions of jQuery
   componentDidMount: ->
-    $(window).on 'keyup', @watchForEscape
+    $(window).bind 'keyup', @watchForEscape
+    $(window).bind 'resize', @updateDimensions
 
   componentWillUnmount: ->
-    $(window).off 'keyup', @watchForEscape
+    $(window).unbind 'keyup', @watchForEscape
+    $(window).unbind 'resize', @updateDimensions
 
   render: ->
     (div {className: 'modal'},
-      (div {className: 'modal-background'})
+      (div {className: 'modal-background', style: @state.dimensions})
       (div {className: 'modal-content'}, @props.children)
     )

--- a/src/style/components/file-dialog.styl
+++ b/src/style/components/file-dialog.styl
@@ -8,6 +8,7 @@
 
   .document-store-footer
     text-align center
+    color #000
     button
       modal-button()
 
@@ -21,6 +22,7 @@
 
   .google-drive-footer
     text-align center
+    color #000
     button
       modal-button()
 
@@ -32,6 +34,7 @@
     padding 150px 0
     text-align center
     font-size 14px
+    color #000
     input
       position absolute
       top 0

--- a/src/style/components/tabbed-panel.styl
+++ b/src/style/components/tabbed-panel.styl
@@ -14,6 +14,7 @@
       list-style none
       padding-left 10px
       li
+        list-style none
         blenderbox-modal-labels()
         font-size 15px
         -webkit-border-radius tab-border-radius
@@ -61,6 +62,7 @@
           margin 3px 0
           padding 3px
           font-size 20px
+          color: #000
           i
             margin-right 7px
         div.selected


### PR DESCRIPTION
Support for clients (such as CODAP) that want to embed the CFM and have the menubar UI rendered in an element specified by the client. The new behavior is specified by passing a new property (appOrMenuElemId). Shouldn't affect the behavior of existing use cases.
- Gulp configuration to allow client to specify alternate build destination.
- Add view-no-frame example demonstrating the menubar being rendered in a client-specified element without an iframe.
- Add appOrMenuElemId property to CFM client configuration.
- Menubar UI renders if appOrMenuElemId property. Client app is only rendered if usingIframe is true.
- Modal dialog code shadows the entire viewport.
- Minor CSS tweaks to explicitly specify styles that might otherwise be overridden by client defaults.