### PR TITLE
CODAP-inspired save improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "jquery": "^2.1.3",
     "jquery-ui": "^1.10.5",
     "lodash": "^3.3.0",
+    "pako": "^0.2.8",
     "react": "^0.13.3",
     "svg-social-icons": "^1.1.0"
   },

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -206,9 +206,15 @@ class CloudFileManagerClient
         saving: metadata
       currentContent = @_createOrUpdateCurrentContent stringContent, metadata
       metadata.provider.save currentContent, metadata, (err) =>
-        return @_error(err) if err
+        if err
+          # disable autosave on save failure; clear "saving..." message
+          metadata.autoSaveDisabled = true
+          @_setState { metadata: metadata, saving: null }
+          return @_error(err)
         if @state.metadata isnt metadata
           @_closeCurrentFile()
+        # reenable autosave on save success
+        metadata.autoSaveDisabled = false
         @_fileChanged 'savedFile', currentContent, metadata, {saved: true}, @_getHashParams metadata
         callback? currentContent, metadata
     else
@@ -359,7 +365,7 @@ class CloudFileManagerClient
     if interval > 1000
       interval = Math.round(interval / 1000)
     if interval > 0
-      @_autoSaveInterval = setInterval (=> @save() if @state.dirty and @state.metadata?.provider?.can 'save'), (interval * 1000)
+      @_autoSaveInterval = setInterval (=> @save() if @state.dirty and not @state.metadata?.autoSaveDisabled and @state.metadata?.provider?.can 'save'), (interval * 1000)
 
   isAutoSaving: ->
     @_autoSaveInterval?

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -240,6 +240,7 @@ class DocumentStoreProvider extends ProviderInterface
     if metadata.providerData.id then params.recordid = metadata.providerData.id
 
     # See if we can patch
+    mimeType = @options.mimeType or 'application/json'
     contentJson = JSON.stringify content
     canOverwrite = metadata.overwritable and @previouslySavedContent?
     if canOverwrite and diff = @_createDiff @previouslySavedContent.getContent(), content
@@ -249,6 +250,7 @@ class DocumentStoreProvider extends ProviderInterface
     if diff? and diffJson.length < contentJson.length
       sendContent = diffJson
       url = patchDocumentUrl
+      mimeType = 'application/json-patch+json'
     else
       if metadata.name then params.recordname = metadata.name
       url = saveDocumentUrl
@@ -261,6 +263,7 @@ class DocumentStoreProvider extends ProviderInterface
       type: 'POST'
       url: url
       data: pako.deflate(JSON.stringify sendContent)
+      contentType: mimeType
       processData: false
       beforeSend: (xhr) ->
         xhr.setRequestHeader('Content-Encoding', 'deflate')

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -217,7 +217,7 @@ class DocumentStoreProvider extends ProviderInterface
 
     $.ajax
       dataType: 'json'
-      method: 'POST'
+      type: 'POST'
       url: url
       data: content.getContentAsJSON()
       context: @
@@ -252,7 +252,7 @@ class DocumentStoreProvider extends ProviderInterface
 
     $.ajax
       dataType: 'json'
-      method: 'POST'
+      type: 'POST'
       url: url
       data: JSON.stringify sendContent
       context: @

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -280,6 +280,8 @@ class DocumentStoreProvider extends ProviderInterface
           responseJson = JSON.parse jqXHR.responseText
           if responseJson.message is 'error.duplicate'
             callback "Unable to create #{metadata.name}.  File already exists."
+          else
+            callback "Unable to save #{metadata.name}: [#{responseJson.message}]"
         catch
           callback "Unable to save #{metadata.name}"
 

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -241,7 +241,7 @@ class GoogleDriveProvider extends ProviderInterface
 
     request = gapi.client.request
       path: path
-      method: method
+      type: method
       params: {uploadType: 'multipart'}
       headers: {'Content-Type': 'multipart/related; boundary="' + boundary + '"'}
       body: body


### PR DESCRIPTION
When saving to the Concord Document Store:
-- compress POST data
-- only send patches if the patches are smaller than the full document would be
On save failure:
-- clear the "Saving..." message
-- disable autosave until next successful manual save (to prevent accumulation of error dialogs)
Use 'type' instead of 'method' in jQuery ajax calls to support older jQuery versions (like the one used by CODAP/SproutCore 1.9).