### PR TITLE
Get hash param decode uri component

### DIFF
--- a/src/code/providers/localstorage-provider.coffee
+++ b/src/code/providers/localstorage-provider.coffee
@@ -38,9 +38,10 @@ class LocalStorageProvider extends ProviderInterface
 
   load: (metadata, callback) ->
     try
-      callback null, cloudContentFactory.createEnvelopedCloudContent window.localStorage.getItem @_getKey metadata.name
+      content = window.localStorage.getItem @_getKey metadata.name
+      callback null, cloudContentFactory.createEnvelopedCloudContent content
     catch e
-      callback "Unable to load: #{e.message}"
+      callback "Unable to load '#{metadata.name}': #{e.message}"
 
   list: (metadata, callback) ->
     list = []

--- a/src/code/utils/get-hash-param.coffee
+++ b/src/code/utils/get-hash-param.coffee
@@ -1,5 +1,12 @@
 module.exports = (param) ->
   ret = null
   location.hash.substr(1).split("&").some (pair) ->
-    pair.split("=")[0] is param and (ret = pair.split("=")[1])
+    key = pair.split("=")[0]
+    if key is param
+      value = pair.split("=")[1]
+      loop
+        value = decodeURIComponent(value)
+        # deal with multiply-encoded values
+        break unless /%20|%25/.test(value)
+      ret = value
   ret


### PR DESCRIPTION
Fix a bug in handling filenames with spaces (and other characters) that I noticed with the localStorage provider but that could affect any provider.
-- call decodeURIComponent in getHashParam()
-- minor improvement to error-handling in localStorage provider

The code in getHashParam() is written to loop until there's nothing left to decode. I actually ran into a situation in which two decodes were necessary but that presumably occurred because I resaved a document using a version of CFM that wasn't decoding.
