### PR TITLE
Read only provider supports remote documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "diff": "^2.2.1",
+    "es6-promise": "^3.0.2",
     "jiff": "^0.7.2",
     "jquery": "^2.1.3",
     "jquery-ui": "^1.10.5",

--- a/src/assets/examples/read-only-with-folders.html
+++ b/src/assets/examples/read-only-with-folders.html
@@ -50,6 +50,50 @@
                 ]}
             ]
           },
+          /* Remote files in array format */
+          {
+            "displayName": "Read Only (remote 'src')",
+            "name": "readOnly",
+            "alphabetize": true,
+            "src": 'https://codap-resources.concord.org/examples/index.json'
+          },
+          /* Remote array format */
+          {
+            "displayName": "Read Only (remote folders)",
+            "name": "readOnly",
+            json: [
+              {
+                type: "label",
+                name: "--- Server Order ---"
+              },
+              {
+                type: "folder",
+                name: "Some Examples",
+                alphabetize: false,
+                url: 'https://codap-resources.concord.org/examples/index.json'
+              },
+              {
+                type: "label",
+                name: "--- Alphabetized Order ---"
+              },
+              {
+                type: "folder",
+                name: "More Examples",
+                alphabetize: true,
+                url: 'https://codap-resources.concord.org/examples/index.json'
+              },
+              {
+                type: "label",
+                name: "--- Folder below shows load failure ---"
+              },
+              {
+                type: "folder",
+                name: "Still More Examples",
+                alphabetize: true,
+                url: 'https://codap-resources.concord.org/examples/load-fail.json'
+              }
+            ]
+          },
           {
             "name": "googleDrive",
             "mimeType": "text/plain",

--- a/src/assets/examples/read-only-with-folders.html
+++ b/src/assets/examples/read-only-with-folders.html
@@ -14,7 +14,9 @@
         mimeType: "text/plain",
         providers: [
           "localStorage",
+          /* Original map format example */
           {
+            "displayName": "Read Only (map)",
             "name": "readOnly",
             "json": {
               "First File Example": "This is the first readonly example",
@@ -29,6 +31,25 @@
               }
             }
           },
+          /* Original example in array format */
+          {
+            "displayName": "Read Only (array)",
+            "name": "readOnly",
+            "json": [
+              { name: "Third File Example", content: "This is the third readonly example" },
+              { name: "Fourth File Example", content: "This is the fourth readonly example" },
+              { name: "Third Folder Example", type: 'folder', 
+                children: [
+                  { name: "Third Folder First File Example", content: "This is the third folder first readonly example" },
+                  { name: "Third Folder Second File Example", content: "This is the third folder second readonly example" }
+                ]},
+              { name: "Fourth Folder Example", type: 'folder',
+                children: [
+                  { name: "Fourth Folder First File Example", content: "This is the fourth folder first readonly example" },
+                  { name: "Fourth Folder Second File Example", content: "This is the fourth folder second readonly example" }
+                ]}
+            ]
+          },
           {
             "name": "googleDrive",
             "mimeType": "text/plain",
@@ -42,7 +63,7 @@
             info: "This version has folders in the read only list"
           }
         }
-      }
+      };
       CloudFileManager.createFrame(options, "wrapper");
     </script>
   </body>

--- a/src/code/globals.coffee
+++ b/src/code/globals.coffee
@@ -3,3 +3,4 @@
 global.$ = require './vendor/touchpunch.js'
 global.React = require 'react'
 global._ = require 'lodash'
+require('es6-promise').polyfill()

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -11,6 +11,11 @@ class CloudMetadata
     {@name, @type, @description, @content, @url, @provider = null, @parent = null, @providerData={}, @overwritable, @sharedContentId, @sharedContentSecretKey} = options
   @Folder: 'folder'
   @File: 'file'
+  @Label: 'label'
+
+  @mapTypeToCloudMetadataType: (iType) ->
+    # for now mapping is 1-to-1 defaulting to 'file'
+    iType or @File
 
   path: ->
     _path = []

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -8,7 +8,7 @@ class CloudFile
 
 class CloudMetadata
   constructor: (options) ->
-    {@name, @type, @content = null, @provider = null, @parent = null, @providerData={}, @overwritable, @sharedContentId, @sharedContentSecretKey} = options
+    {@name, @type, @description, @content, @url, @provider = null, @parent = null, @providerData={}, @overwritable, @sharedContentId, @sharedContentSecretKey} = options
   @Folder: 'folder'
   @File: 'file'
 

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -8,7 +8,7 @@ class CloudFile
 
 class CloudMetadata
   constructor: (options) ->
-    {@name, @type, @provider = null, @parent = null, @providerData={}, @overwritable, @sharedContentId, @sharedContentSecretKey} = options
+    {@name, @type, @content = null, @provider = null, @parent = null, @providerData={}, @overwritable, @sharedContentId, @sharedContentSecretKey} = options
   @Folder: 'folder'
   @File: 'file'
 

--- a/src/code/utils/is-array.coffee
+++ b/src/code/utils/is-array.coffee
@@ -1,0 +1,2 @@
+# https://coffeescript-cookbook.github.io/chapters/arrays/check-type-is-array
+module.exports = (value) -> Array.isArray value or {}.toString.call value is '[object Array]'

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -38,6 +38,7 @@ module.exports =
   "~FILE_DIALOG.REMOVE": "Delete"
   "~FILE_DIALOG.REMOVE_CONFIRM": "Are you sure you want to delete %{filename}?"
   "~FILE_DIALOG.LOADING": "Loading..."
+  "~FILE_DIALOG.LOAD_FOLDER_ERROR": "*** Error loading folder contents ***"
 
   "~DOWNLOAD_DIALOG.DOWNLOAD": "Download"
   "~DOWNLOAD_DIALOG.CANCEL": "Cancel"

--- a/src/code/views/file-dialog-tab-view.coffee
+++ b/src/code/views/file-dialog-tab-view.coffee
@@ -21,7 +21,10 @@ FileListFile = React.createFactory React.createClass
     @lastClick = now
 
   render: ->
-    (div {key: @props.key, className: (if @props.selected then 'selected' else ''), onClick: @fileSelected},
+    (div {key: @props.key
+          , className: (if @props.selected then 'selected' else '')
+          , title: @props.metadata.description or undefined
+          , onClick: @fileSelected},
       (React.DOM.i {className: if @props.metadata.type is CloudMetadata.Folder then 'icon-inspectorArrow-collapse' else 'icon-noteTool'})
       @props.metadata.name
     )

--- a/src/code/views/file-dialog-tab-view.coffee
+++ b/src/code/views/file-dialog-tab-view.coffee
@@ -21,11 +21,13 @@ FileListFile = React.createFactory React.createClass
     @lastClick = now
 
   render: ->
+    selectableClass = if @props.metadata.type isnt CloudMetadata.Label then 'selectable' else ''
+    selectedClass = if @props.selected then 'selected' else ''
     (div {key: @props.key
-          , className: (if @props.selected then 'selected' else '')
+          , className: "#{selectableClass} #{selectedClass}"
           , title: @props.metadata.description or undefined
-          , onClick: @fileSelected},
-      (React.DOM.i {className: if @props.metadata.type is CloudMetadata.Folder then 'icon-inspectorArrow-collapse' else 'icon-noteTool'})
+          , onClick: if @props.metadata.type isnt CloudMetadata.Label then @fileSelected else undefined },
+      (React.DOM.i {className: if @props.metadata.type is CloudMetadata.Folder then 'icon-inspectorArrow-collapse' else if @props.metadata.type is CloudMetadata.File then 'icon-noteTool'})
       @props.metadata.name
     )
 
@@ -55,7 +57,7 @@ FileList = React.createFactory React.createClass
   render: ->
     list = []
     if @props.folder isnt null
-      list.push (div {key: 'parent', onClick: @parentSelected}, (React.DOM.i {className: 'icon-paletteArrow-collapse'}), 'Parent Folder')
+      list.push (div {key: 'parent', className: 'selectable', onClick: @parentSelected}, (React.DOM.i {className: 'icon-paletteArrow-collapse'}), 'Parent Folder')
     for metadata, i in @props.list
       list.push (FileListFile {key: i, metadata: metadata, selected: @props.selectedFile is metadata, fileSelected: @props.fileSelected, fileConfirmed: @props.fileConfirmed})
 

--- a/src/style/components/tabbed-panel.styl
+++ b/src/style/components/tabbed-panel.styl
@@ -68,7 +68,7 @@
         div.selected
           color: #fff
           background-color #72bfca
-        div:hover
+        div.selectable:hover
           color: #fff
           background-color: green-blue
       .buttons


### PR DESCRIPTION
Supports loading of remote documents as well as remote directories containing lists of documents, thus allowing arbitrary sample document libraries.
-- expands the JSON format to support the new features while maintaining compatibility with the old JSON format
-- adds a 'description' property for documents, which is presented as a tooltip
-- adds a 'url' property for documents which is used to load remote documents
-- adds a 'label' type which is used to show dividers and other non-selectable items in file lists
-- adds the 'es6-promise' module for use in handling async requests for remote directories