### PR TITLE
Add gulp command-line options (--nojQuery and --codap) for CODAP configuration

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -3,9 +3,19 @@ var argv = require('yargs').argv,
     production = !!argv.production,
     buildInfo = argv.buildInfo || 'development build (' + (new Date()) + ')',
     src = './src',
-    dest  = argv.dest ? argv.dest : './dist';
+    dest  = argv.dest ? argv.dest : './dist',
+    noMap = !!argv.noMap,
+    nojQuery = !!argv.nojQuery,
+    codap = !!argv.codap,
+    assetsSrc = codap ? src + '/assets/img/*.*' : src + '/assets/**/*.*',
+    assetsDst = codap ? dest + '/img/' : dest;
 
 module.exports = {
+  flags: {
+    noMap: noMap,
+    nojQuery: nojQuery,
+    codap: codap
+  },
   browserify: {
     app: {
       watch: ['./package.json', src + '/code/**/*.*', '!' + src + '/code/globals.coffee'],
@@ -28,9 +38,9 @@ module.exports = {
     dest: dest + '/css/'
   },
   assets: {
-    watch: src + '/assets/**/*.*',
-    src: src + '/assets/**/*.*',
-    dest: dest
+    watch: assetsSrc,
+    src: assetsSrc,
+    dest: assetsDst
   },
   deploy: {
     src: dest + '/**/*'

--- a/gulp/tasks/browserify-task.js
+++ b/gulp/tasks/browserify-task.js
@@ -4,9 +4,15 @@ var source      = require("vinyl-source-stream");
 var coffeeify   = require('coffeeify');
 var versionify  = require('package-json-versionify');
 var pkgVersion  = require('../../package.json').version;
+var gulpif      = require('gulp-if');
+var rename      = require('gulp-rename');
 var replace     = require('gulp-replace');
 var production  = require('../config').production;
 var config      = require('../config').browserify;
+var flags       = require('../config').flags;
+var noMap       = flags && flags.noMap;
+var nojQuery    = flags && flags.nojQuery;
+var codap       = flags && flags.codap;
 var beep        = require('beepbeep');
 
 var errorHandler = function (error) {
@@ -17,7 +23,7 @@ var errorHandler = function (error) {
 
 gulp.task('browserify-app', function(){
   var b = browserify({
-    debug: !production,
+    debug: !production && !noMap,
     extensions: ['.coffee'],
     standalone: "CloudFileManager"
   });
@@ -28,18 +34,27 @@ gulp.task('browserify-app', function(){
     .on('error', errorHandler)
     .pipe(source('app.js'))
     .pipe(replace(/__PACKAGE_VERSION__/g, pkgVersion))
+    .pipe(gulpif(codap, rename('app.js.ignore')))
     .pipe(gulp.dest(config.app.dest));
 });
 
 gulp.task('browserify-globals', function(){
   var b = browserify({
-    debug: !production
+    debug: !production && !noMap,
   });
+  if(nojQuery) {
+    b.exclude('jquery');
+  }
   b.transform(coffeeify);
   b.add(config.globals.src);
   return b.bundle()
     .on('error', errorHandler)
     .pipe(source('globals.js'))
+    .pipe(gulpif(nojQuery, replace(/(var)*[ ]*jQuery[ ]*=/g,
+                                    function(iMatch) {
+                                      return '//' + iMatch;
+                                    })))
+    .pipe(gulpif(codap, rename('globals.js.ignore')))
     .pipe(gulp.dest(config.globals.dest));
 });
 

--- a/gulp/tasks/browserify-task.js
+++ b/gulp/tasks/browserify-task.js
@@ -50,7 +50,7 @@ gulp.task('browserify-globals', function(){
   return b.bundle()
     .on('error', errorHandler)
     .pipe(source('globals.js'))
-    .pipe(gulpif(nojQuery, replace(/(var)*[ ]*jQuery[ ]*=/g,
+    .pipe(gulpif(nojQuery, replace(/.*?jQuery\s*=.*\n*/g,
                                     function(iMatch) {
                                       return '//' + iMatch;
                                     })))

--- a/gulp/tasks/css-task.js
+++ b/gulp/tasks/css-task.js
@@ -1,11 +1,20 @@
 var gulp       = require('gulp');
+var gulpif     = require('gulp-if');
 var config     = require('../config').css;
 var stylus     = require('gulp-stylus');
 var concat     = require('gulp-concat');
+var replace	   = require('gulp-replace');
+var flags	   = require('../config').flags;
+var codap	   = flags && flags.codap;
 
 gulp.task('css', function() {
   gulp.src(config.src)
     .pipe(stylus({ compress: false}))
     .pipe(concat('app.css'))
+    .pipe(gulpif(codap, replace('url(', 'static_url(')))
+    .pipe(gulpif(codap, replace('../fonts', 'webfonts')))
+    .pipe(gulpif(codap, replace('MuseoSans_500_italic', 'MuseoSans_500_Italic')))
+    .pipe(gulpif(codap, replace('?ndvjg4', '')))
+    .pipe(gulpif(codap, replace('../img', 'cloud-file-manager/img')))
     .pipe(gulp.dest(config.dest));
 });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-concat": "^2.5.2",
     "gulp-gh-pages": "^0.5.4",
     "gulp-if": "^1.2.5",
+    "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
     "gulp-stylus": "^2.0.1",
     "package-json-versionify": "^1.0.1",


### PR DESCRIPTION
Support CODAP gulp configuration via command-line options rather than as a branch or other less desirable alternative.
  --nojQuery flag excludes jQuery for use with clients that already have jQuery installed.
  --codap flag adds '.ignore' to the .js filenames to hide them from the SproutCore build system.
  --codap flag also excludes most assets except a handful of images, since the others are either already present in CODAP (e.g. fonts) or not used in CODAP (e.g. examples).
  --noMap flag isn't CODAP-specific -- it disables inclusion of source maps thus allowing debugging with the browser's JavaScript debugger rather than the CoffeeScript debugger.

Shouldn't affect the behavior of the build unless one of the new options is specified.