### PR TITLE
Fix share dialog when used in CODAP/CFM

### DIFF
--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -231,7 +231,8 @@ class DocumentStoreProvider extends ProviderInterface
           _permissions: 0
         callback null, data.id
       error: ->
-        callback "Unable to save "+metadata.name
+        docName = metadata?.name or 'document'
+        callback "Unable to save #{docName}"
 
   save: (cloudContent, metadata, callback) ->
     content = cloudContent.getContent()

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -214,13 +214,18 @@ class DocumentStoreProvider extends ProviderInterface
       shareEditKey: null            # strip these out of the shared data if they
       sharedDocumentId: null        # exist (they'll be re-added on success)
 
+    mimeType = @options.mimeType or 'application/json'
     url = @_addParams(saveDocumentUrl, params)
 
     $.ajax
       dataType: 'json'
       type: 'POST'
       url: url
-      data: content.getContentAsJSON()
+      contentType: mimeType
+      data: pako.deflate content.getContentAsJSON()
+      processData: false
+      beforeSend: (xhr) ->
+        xhr.setRequestHeader('Content-Encoding', 'deflate')
       context: @
       xhrFields:
         withCredentials: false

--- a/src/style/components/share-dialog.styl
+++ b/src/style/components/share-dialog.styl
@@ -1,5 +1,6 @@
 .share-dialog
   width 600px
+  color #000
 
   .share-top-dialog
     padding 30px


### PR DESCRIPTION
* default text color to black in share dialog
* add existence test for metadata when handling errors such as failure to save when enabling sharing
* saving for sharing purposes use same compression protocol as simply saving
