### PR TITLE
Add sourceURL line in CODAP build to simplify debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
     "gulp-concat": "^2.5.2",
     "gulp-gh-pages": "^0.5.4",
     "gulp-if": "^1.2.5",
+    "gulp-inject-string": "^1.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
     "gulp-stylus": "^2.0.1",
     "package-json-versionify": "^1.0.1",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.1.5",
+    "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "yargs": "^3.6.0"
   }


### PR DESCRIPTION
Add sourceURL line in CODAP build to simplify debugging for clients that dynamically load CFM (e.g. CODAP). While in the build system, use the 'extname' option of gulp-rename to simplify file renaming.

@dougmartin Since you reviewed the earlier gulp changes, you may want to take a look at these.