### PR TITLE
Fix Google Drive save regression

### DIFF
--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -241,7 +241,7 @@ class GoogleDriveProvider extends ProviderInterface
 
     request = gapi.client.request
       path: path
-      type: method
+      method: method
       params: {uploadType: 'multipart'}
       headers: {'Content-Type': 'multipart/related; boundary="' + boundary + '"'}
       body: body


### PR DESCRIPTION
Oops! In an earlier spate of jQuery 1.6 compatibility changes -- renaming 'method' to 'type' in jQuery ajax calls -- I managed to make the same change in the GoogleDriveProvider, which doesn't use ajax and therefore shouldn't be changed.