### PR TITLE
Support opting out of CFM wrapped file format

### DIFF
--- a/src/assets/examples/all-providers.html
+++ b/src/assets/examples/all-providers.html
@@ -41,11 +41,11 @@
             help: "http://lmgtfy.com/"
           }
         }
-      }
+      };
       CloudFileManager.createFrame(options, "wrapper", function (event) {
         if (event.type == 'connected') {
           var client = event.data.client;
-          client.insertMenuItemAfter('openFileDialog', {"name": "Import data...", action: client.importDataDialog.bind(client)})
+          client.insertMenuItemAfter('openFileDialog', {"name": "Import data...", action: client.importDataDialog.bind(client)});
         }
       });
     </script>

--- a/src/assets/examples/auto-saving.html
+++ b/src/assets/examples/auto-saving.html
@@ -40,7 +40,7 @@
             info: "This version auto saves every 5 seconds"
           }
         }
-      }
+      };
       CloudFileManager.createFrame(options, "wrapper");
     </script>
   </body>

--- a/src/assets/examples/example-app/index.html
+++ b/src/assets/examples/example-app/index.html
@@ -106,6 +106,7 @@
             case 'newedFile':
             case 'openedFile':
               setContent(event.data.content);
+              if(event.callback) event.callback();
               focus();
               break;
 

--- a/src/assets/examples/example-app/index.html
+++ b/src/assets/examples/example-app/index.html
@@ -39,6 +39,7 @@
       }
 
       function setContent(cfmContent) {
+        if(typeof cfmContent !== "string") cfmContent = JSON.stringify(cfmContent);
         document.getElementById("text").value = cfmContent;
       }
 

--- a/src/assets/examples/example-app/index.html
+++ b/src/assets/examples/example-app/index.html
@@ -15,6 +15,8 @@
     <script type="text/javascript">
       var cfmClient;
 
+      // Disable "Expected an assignment or function call and instead saw an expression" warning
+      /*jshint -W030 */
       function newFile() {
         cfmClient && cfmClient.newFileDialog();
       }
@@ -115,7 +117,7 @@
         });
       }
 
-      document.getElementById("text").focus()
+      document.getElementById("text").focus();
     </script>
   </body>
 </html>

--- a/src/assets/examples/index.html
+++ b/src/assets/examples/index.html
@@ -13,6 +13,7 @@
       <li><a href="all-providers.html">All Providers</a></li>
       <li><a href="no-frame.html">No Frame</a></li>
       <li><a href="view-no-frame.html">View Without Frame</a></li>
+      <li><a href="view-no-frame-nowrap.html">View Without Frame (unwrapped)</a></li>
       <li><a href="auto-saving.html">Auto Saving</a></li>
       <li><a href="new-does-not-use-new-tab.html">New Does Not Open in New Tab</a></li>
       <li><a href="read-only-with-folders.html">Read Only with Folders</a></li>

--- a/src/assets/examples/menu-madness.html
+++ b/src/assets/examples/menu-madness.html
@@ -43,12 +43,12 @@
       };
 
       function createMenuItem(text, disabled) {
-        disabled = disabled || false
+        disabled = disabled || false;
         return {
           name: text,
-          action: function () { alert("text")},
+          action: function () { alert("text"); },
           enabled: !disabled
-        }
+        };
       }
       CloudFileManager.createFrame(options, "wrapper", function (event) {
         if (event.type == 'connected') {
@@ -57,7 +57,7 @@
             .prependMenuItem(createMenuItem("#2 added via prependMenuItem()"))
             .replaceMenuItem('openFileDialog', createMenuItem("#3 added via replaceMenuItem('openFileDialog')"))
             .insertMenuItemBefore(6, createMenuItem("#4 added via insertMenuItemBefore(6)"))
-            .insertMenuItemAfter('downloadDialog', createMenuItem("#5 added via insertMenuItemAfter('downloadDialog')"))
+            .insertMenuItemAfter('downloadDialog', createMenuItem("#5 added via insertMenuItemAfter('downloadDialog')"));
         }
       });
     </script>

--- a/src/assets/examples/new-does-not-use-new-tab.html
+++ b/src/assets/examples/new-does-not-use-new-tab.html
@@ -38,7 +38,7 @@
           },
           newFileOpensInNewTab: false
         }
-      }
+      };
       CloudFileManager.createFrame(options, "wrapper");
     </script>
   </body>

--- a/src/assets/examples/no-frame.html
+++ b/src/assets/examples/no-frame.html
@@ -18,6 +18,8 @@
     <script type="text/javascript">
       var cfmClient, cfmContent;
 
+      // Disable "Expected an assignment or function call and instead saw an expression" warning
+      /*jshint -W030 */
       function newFile() {
         cfmClient && cfmClient.newFileDialog();
       }
@@ -99,7 +101,7 @@
           }
         ]
       };
-      CloudFileManager.init(clientOptions)
+      CloudFileManager.init(clientOptions);
       CloudFileManager.clientConnect(function (event) {
         console.log(event);
         switch (event.type) {
@@ -119,7 +121,7 @@
         }
       });
 
-      document.getElementById("text").focus()
+      document.getElementById("text").focus();
     </script>
   </body>
 </html>

--- a/src/assets/examples/no-frame.html
+++ b/src/assets/examples/no-frame.html
@@ -116,6 +116,7 @@
             case 'newedFile':
             case 'openedFile':
               setContent(event.data.content);
+              if(event.callback) event.callback();
               focus();
               break;
         }

--- a/src/assets/examples/real-time-api.html
+++ b/src/assets/examples/real-time-api.html
@@ -40,7 +40,7 @@
             info: "This version uses the Google Drive Realtime API"
           }
         }
-      }
+      };
       CloudFileManager.createFrame(options, "wrapper");
     </script>
   </body>

--- a/src/assets/examples/view-no-frame-nowrap.html
+++ b/src/assets/examples/view-no-frame-nowrap.html
@@ -16,7 +16,8 @@
       }
     </style>
     <script type="text/javascript">
-      var cfmClient, cfmContent;
+      /* global CloudFileManager */
+      var cfmClient, cfmContent = {};
 
       // Disable "Expected an assignment or function call and instead saw an expression" warning
       /*jshint -W030 */
@@ -37,19 +38,48 @@
         cfmClient && cfmClient.saveFileAsDialog(getContent());
       }
 
-      function getContent() {
-        cfmContent = document.getElementById("text").value;
+      function getContent(iSharedMetadata) {
+        cfmContent.text = document.getElementById("text").value;
+        cfmContent.metadata = $.extend(true, {}, iSharedMetadata);
         return cfmContent;
       }
 
       function setContent(_cfmContent) {
-        cfmContent = _cfmContent;
-        document.getElementById("text").value = cfmContent;
+        cfmContent.metadata = {};
+        if(typeof _cfmContent === "string") {
+          // convert simple strings
+          cfmContent.text = _cfmContent;
+        }
+        else if(typeof _cfmContent === "object") {
+          if(_cfmContent.text === undefined) {
+            // convert files not written by this example
+            cfmContent.text = JSON.stringify(_cfmContent);
+          }
+          else {
+            // extract the text and metadata if it's one of our files
+            cfmContent.text = _cfmContent.text;
+            if(_cfmContent.metadata) {
+              cfmContent.metadata = $.extend(true, {}, _cfmContent.metadata);
+            }
+          }
+        }
+        else {
+          // convert files not written by this example
+          cfmContent.text = JSON.stringify(_cfmContent);
+        }
+        document.getElementById("text").value = cfmContent.text;
+        return cfmContent.metadata;
+      }
+
+      function setMetadata(iSharedMetadata) {
+        var dirty = !_.isEqual(cfmContent.metadata || {}, iSharedMetadata || {});
+        cfmContent.metadata = $.extend(true, {}, iSharedMetadata);
+        if(dirty) cfmClient.dirty();
       }
 
       function connected(client) {
         cfmClient = client;
-        cfmContent = document.getElementById("text").value;
+        cfmContent.text = document.getElementById("text").value;
       }
 
       function changed() {
@@ -64,23 +94,22 @@
   <body>
     <h2>Demo App</h2>
     <p>
-      This simple demo app uses the textarea below to edit text files.  You can either use the menu bar or the buttons below to open, save and create new files.
+      This simple demo app uses the textarea below to edit text files. You can use
+      the menu bar below to open, save and create new files.
     </p>
     <div>
       <textarea cols="50" rows="10" id="text"></textarea>
     </div>
-    <div id="buttons">
-      <button onclick="newFile()">New</button>
-      <button onclick="openFile()">Open</button>
-      <button onclick="saveFile()">Save</button>
-      <button onclick="saveFileAs()">Save As</button>
-    </div>
+    <!-- CFM menu bar will attach here -->
+    <div id="menuBar"></div>
     <script type="text/javascript">
       var clientOptions = {
         mimeType: "text/plain",
         appName: "CFM_Demo",
         appVersion: "0.1",
         appBuildNum: "1",
+        appOrMenuElemId: "menuBar",
+        wrapFileContent: false,
         providers: [
           "localStorage",
           {
@@ -103,21 +132,29 @@
       };
       CloudFileManager.init(clientOptions);
       CloudFileManager.clientConnect(function (event) {
-        console.log(event);
+        var result;
         switch (event.type) {
           case 'connected':
             connected(event.data.client);
             break;
 
             case 'getContent':
-              event.callback(getContent());
+              event.callback(getContent(event.data.shared));
               break;
 
             case 'newedFile':
             case 'openedFile':
-              setContent(event.data.content);
-              if(event.callback) event.callback();
+              result = setContent(event.data.content);
+              if(event.callback) event.callback(null, result);
               focus();
+              break;
+
+            case 'sharedFile':
+              setMetadata(event.data.shared);
+              break;
+
+            case 'unsharedFile':
+              setMetadata({});
               break;
         }
       });

--- a/src/assets/examples/view-no-frame.html
+++ b/src/assets/examples/view-no-frame.html
@@ -19,8 +19,8 @@
       /* global CloudFileManager */
       var cfmClient, cfmContent;
 
-      /* exported newFile, openFile, saveFile, saveFileAs, getContent, setContent,
-                  connected, changed, focus */
+      // Disable "Expected an assignment or function call and instead saw an expression" warning
+      /*jshint -W030 */
       function newFile() {
         cfmClient && cfmClient.newFileDialog();
       }

--- a/src/assets/examples/view-no-frame.html
+++ b/src/assets/examples/view-no-frame.html
@@ -115,6 +115,7 @@
             case 'newedFile':
             case 'openedFile':
               setContent(event.data.content);
+              if(event.callback) event.callback();
               focus();
               break;
         }

--- a/src/code/ui.coffee
+++ b/src/code/ui.coffee
@@ -20,14 +20,17 @@ class CloudFileManagerUIMenu
     setEnabled = (action) ->
       switch action
         when 'revertSubMenu'
+          # revert sub-menu state depends on presence of shareEditKey
           -> (client.state.openedContent? and client.state.metadata?) or client.state.currentContent?.get("shareEditKey")?
         when 'revertToLastOpenedDialog'
           -> client.state.openedContent? and client.state.metadata?
         when 'shareGetLink', 'shareSubMenu'
           -> client.state.shareProvider?
         when 'revertToSharedDialog'
+          # revert to shared menu item state depends on sharedDocumentId
           -> client.state.currentContent?.get("sharedDocumentId")
         when 'shareUpdate'
+          # shareUpdate menu item state depends on presence of shareEditKey
           -> client.state.currentContent?.get("shareEditKey")?
         else
           true

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -52,12 +52,12 @@ module.exports =
   "~SHARE_DIALOG.COPY_SUCCESS": "The share url has been copied to the clipboard."
   "~SHARE_DIALOG.COPY_ERROR": "Sorry, the share url was not able to be copied to the clipboard."
 
-  "~CONFIRM.OPEN_FILE": "You have unsaved changes.  Are you sure you want open a new file?"
-  "~CONFIRM.NEW_FILE": "You have unsaved changes.  Are you sure you want a new file?"
-  "~CONFIRM.REVERT_TO_LAST_OPENED": "Are you sure you want revert the file to its most recently opened state?"
-  "~CONFIRM.REVERT_TO_SHARED_VIEW": "Are you sure you want revert the file to currently shared view?"
+  "~CONFIRM.OPEN_FILE": "You have unsaved changes. Are you sure you want to open a new document?"
+  "~CONFIRM.NEW_FILE": "You have unsaved changes. Are you sure you want to create a new document?"
+  "~CONFIRM.REVERT_TO_LAST_OPENED": "Are you sure you want to revert the document to its most recently opened state?"
+  "~CONFIRM.REVERT_TO_SHARED_VIEW": "Are you sure you want to revert the document to its most recently shared state?"
 
-  "~LOCAL_FILE_DIALOG.DROP_FILE_HERE": "Drop file here or click here to select file."
+  "~LOCAL_FILE_DIALOG.DROP_FILE_HERE": "Drop file here or click here to select a file."
   "~LOCAL_FILE_DIALOG.MULTIPLE_FILES_SELECTED": "Sorry, you can choose only one file to open."
   "~LOCAL_FILE_DIALOG.MULTIPLE_FILES_DROPPED": "Sorry, you can't drop more than one file."
 

--- a/src/code/views/share-dialog-view.coffee
+++ b/src/code/views/share-dialog-view.coffee
@@ -42,11 +42,13 @@ module.exports = React.createClass
     linkTabSelected: true
 
   getSharedDocumentId: ->
+    # extract sharedDocumentId from CloudContent
     @props.client.state.currentContent?.get "sharedDocumentId"
 
   getShareLink: ->
     sharedDocumentId = @getSharedDocumentId()
     if sharedDocumentId
+      # share link combines document URL with sharedDocumentId
       "#{@props.client.getCurrentUrl()}#shared=#{sharedDocumentId}"
     else
       null


### PR DESCRIPTION
Adds support for clients to opt out of the CFM wrapped file format.
Add callback to 'openedFile' API for client to indicate successful completion of open.
Clients that opt out of the CFM wrapper file format are responsible for combining CFM shared metadata with the content in 'getContent' and unpacking CFM shared metadata from the content in 'openedFile'.
Use protocol-relative URLs for http/https compatibility.
Add example document demonstrating opting out of the CFM wrapped file format.
Made the other examples consistent with the 'openedFile' API changes by calling back to acknowledge success.
Eliminated a number of JSHint warnings in examples.

@dougmartin Since @sfentress is out of town for a while, you're the likely candidate to review this. I already did a side-by-side review with Sam but this has been modified somewhat since then.
