### PR TITLE
Use run key from LARA when saving as a student

### DIFF
--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -4,6 +4,7 @@ CloudFileManagerUIMenu = (require './ui').CloudFileManagerUIMenu
 CloudFileManagerClient = (require './client').CloudFileManagerClient
 
 getHashParam = require './utils/get-hash-param'
+getQueryParam = require './utils/get-query-param'
 
 class CloudFileManager
 
@@ -24,6 +25,7 @@ class CloudFileManager
       sharedContentId: getHashParam "shared"
       fileParams: getHashParam "file"
       copyParams: getHashParam "copy"
+      runKey: getQueryParam "runKey"
     }
 
     @client.setAppOptions @appOptions

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -198,9 +198,6 @@ class DocumentStoreProvider extends ProviderInterface
       xhrFields:
         {withCredentials}
       success: (data) ->
-        # record previously saved content for patching purposes
-        @previouslySavedContent = if @options.patch then _.cloneDeep(data) else null
-
         content = cloudContentFactory.createEnvelopedCloudContent data
 
         # for documents loaded by id or other means (besides name),

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -273,6 +273,7 @@ class DocumentStoreProvider extends ProviderInterface
     if metadata.providerData.id then params.recordid = metadata.providerData.id
 
     # See if we can patch
+    willPatch = false
     mimeType = 'application/json' # Document Store requires JSON currently
     contentJson = JSON.stringify content
     canOverwrite = metadata.overwritable and @previouslySavedContent?
@@ -288,10 +289,26 @@ class DocumentStoreProvider extends ProviderInterface
       sendContent = diffJson
       url = patchDocumentUrl
       mimeType = 'application/json-patch+json'
+      willPatch = true
     else
       if metadata.filename then params.recordname = metadata.filename
       url = saveDocumentUrl
       sendContent = contentJson
+
+    if not willPatch
+      # If we are saving for the first time as a student in a LARA activity, then we do not have
+      # authorization on the current document. However, we should have a runKey query parameter.
+      # When we save with this runKey, the document will save our changes to a copy of the document,
+      # owned by us.
+      #
+      # When we successfully save, we will get the id of the new document in the response, and use
+      # this id for future saving. We can then save via patches, and don't need the runKey.
+      #
+      # `willPatch` will always be false for an individual user's first save of a session. There
+      # does not seem to be a way to see if we've launched a document that we own, so we just
+      # assume we don't own it.
+      if @client.appOptions.hashParams.runKey
+        params.runKey = @client.appOptions.hashParams.runKey
 
     url = @_addParams(url, params)
 

--- a/src/code/utils/get-query-param.coffee
+++ b/src/code/utils/get-query-param.coffee
@@ -1,0 +1,9 @@
+module.exports = (param) ->
+  param = param.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]")
+  regexS = "[\\?&]" + param + "=([^&#]*)"
+  regex = new RegExp regexS
+  results = regex.exec window.location.href
+  if results?.length > 1
+    return decodeURIComponent results[1]
+  else
+    return null


### PR DESCRIPTION
This allows student to launch shared documents from LARA and save back to their own copies.

When a student launches using from LARA using a document on the document-server which was shared by an author, they do not have write-access to that file. Instead, LARA also providers them with the runKey associated with that document in the url as a query parameter.

If we save to the same document using that runKey, then the document-server will automatically create a copy for us, allowing us to save our changes to it. It will then pass down the new id for the file we have ownership to, allowing us to save to that new document from then on.

We were already capturing a using the new id, but two changes had to be introduced:

1. Capture the runKey and use it on the first save
2. Don't try to save via patch on the first save of a session

The second point means that we won't be as efficient in our first save, as we may do a full-save even on a document we already own. Unfortunately, it doesn't seem that there is a way of distinguishing between a document we own and one we don't, until we have a successful first save. At which point, the record id returned by the server will always be one that we own. 