### PR TITLE
Improve runKey handling

### DIFF
--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -26,6 +26,7 @@ class CloudFileManager
       fileParams: getHashParam "file"
       copyParams: getHashParam "copy"
       runKey: getQueryParam "runKey"
+      runAsGuest: (getQueryParam "runAsGuest") is "true"
     }
 
     @client.setAppOptions @appOptions

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -220,7 +220,8 @@ class CloudFileManagerClient
     provider = @providers[providerName]
     if provider
       provider.authorized (authorized) =>
-        if authorized
+        # we can open the document without authorization in some cases
+        if authorized or not provider.isAuthorizationRequired()
           provider.openSaved providerParams, (err, content, metadata) =>
             return @alert(err) if err
             @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata
@@ -437,7 +438,11 @@ class CloudFileManagerClient
       clearInterval @_autoSaveInterval
 
     shouldAutoSave = =>
-      @state.dirty and not @state.metadata?.autoSaveDisabled and not @isSaveInProgress() and @state.metadata?.provider?.can 'save'
+      @state.dirty and
+        not @appOptions.hashParams?.runAsGuest and
+        not @state.metadata?.autoSaveDisabled and
+        not @isSaveInProgress() and
+        @state.metadata?.provider?.can 'save'
 
     # in case the caller uses milliseconds
     if interval > 1000

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -240,9 +240,11 @@ class CloudFileManagerClient
       @saveContent stringContent, callback
 
   saveContent: (stringContent, callback = null) ->
-    if @state.metadata?.provider?
-      @state.metadata.provider.authorized (isAuthorized) =>
-        if isAuthorized
+    provider = @state.metadata?.provider
+    if provider?
+      provider.authorized (isAuthorized) =>
+        # we can save the document without authorization in some cases
+        if isAuthorized or not provider.isAuthorizationRequired()
           @saveFile stringContent, @state.metadata, callback
         else
           @confirmAuthorizeAndSave stringContent, callback
@@ -439,7 +441,6 @@ class CloudFileManagerClient
 
     shouldAutoSave = =>
       @state.dirty and
-        not @appOptions.hashParams?.runAsGuest and
         not @state.metadata?.autoSaveDisabled and
         not @isSaveInProgress() and
         @state.metadata?.provider?.can 'save'

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -64,6 +64,10 @@ class DocumentStoreProvider extends ProviderInterface
 
   previouslySavedContent: null
 
+  # if 'runAsGuest' is specified, we don't need to authenticate at all
+  isAuthorizationRequired: ->
+    not (@client.appOptions.hashParams.runKey and @client.appOptions.hashParams.runAsGuest)
+
   authorized: (@authCallback) ->
     if @authCallback
       if @user
@@ -215,7 +219,7 @@ class DocumentStoreProvider extends ProviderInterface
         403: =>
           @user = null
           callback "Unable to load '#{metadata.name}' due to a permissions error.\nYou may need to log in again.", 403
-      error: ->
+      error: (jqXHR) ->
         return if jqXHR.status is 403 # let statusCode handler deal with it
         message = if metadata.sharedContentId
           "Unable to load document '#{metadata.sharedContentId}'. Perhaps the file was not shared?"
@@ -262,7 +266,7 @@ class DocumentStoreProvider extends ProviderInterface
         403: =>
           @user = null
           callback "Unable to share '#{metadata.name}' due to a permissions error.\nYou may need to log in again.", 403
-      error: ->
+      error: (jqXHR) ->
         return if jqXHR.status is 403 # let statusCode handler deal with it
         docName = metadata?.filename or 'document'
         callback "Unable to save #{docName}"
@@ -359,7 +363,7 @@ class DocumentStoreProvider extends ProviderInterface
         403: =>
           @user = null
           callback "Unable to remove '#{metadata.name}' due to a permissions error.\nYou may need to log in again.", 403
-      error: ->
+      error: (jqXHR) ->
         return if jqXHR.status is 403 # let statusCode handler deal with it
         callback "Unable to remove #{metadata.name}"
 
@@ -379,7 +383,7 @@ class DocumentStoreProvider extends ProviderInterface
         403: =>
           @user = null
           callback "Unable to rename '#{metadata.name}' due to a permissions error.\nYou may need to log in again.", 403
-      error: ->
+      error: (jqXHR) ->
         return if jqXHR.status is 403 # let statusCode handler deal with it
         callback "Unable to rename #{metadata.name}"
 

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -276,6 +276,9 @@ class DocumentStoreProvider extends ProviderInterface
 
     params = {}
     if metadata.providerData.id then params.recordid = metadata.providerData.id
+    # pass the runKey if one is provided
+    if @client.appOptions.hashParams.runKey
+      params.runKey = @client.appOptions.hashParams.runKey
 
     # See if we can patch
     willPatch = false

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -194,6 +194,7 @@ class DocumentStoreProvider extends ProviderInterface
       dataType: 'json'
       data:
         recordid: metadata.providerData?.id or metadata.sharedContentId
+        runKey: if @client.appOptions.hashParams.runKey then @client.appOptions.hashParams.runKey else undefined
       context: @
       xhrFields:
         {withCredentials}


### PR DESCRIPTION
- If runKey was passed as URL parameter, pass it to document server when loading or saving the document.
This is necessary to support use cases such as teachers viewing student work.
- Support opening and saving documents without authorization when 'runAsGuest' parameter is specified
- Fix copy/paste errors in some request error handlers