### PR TITLE
Fix download and upload

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -433,7 +433,7 @@ class CloudFileManagerClient
   dirty: (isDirty = true)->
     @_setState
       dirty: isDirty
-      saved: false if isDirty
+      saved: @state.saved and not isDirty
 
   autoSave: (interval) ->
     if @_autoSaveInterval

--- a/src/code/views/download-dialog-view.coffee
+++ b/src/code/views/download-dialog-view.coffee
@@ -35,8 +35,10 @@ module.exports = React.createClass
 
   download: (e) ->
     makeBlobURL = (msg) ->
+      wURL = window.URL or window.webkitURL
       blob = new Blob([msg], {type: 'text/plain'})
-      window.URL.createObjectURL(blob)
+      if (wURL)
+        wURL.createObjectURL(blob)
 
     if @state.trimmedFilename.length > 0
       json = @props.content.getContent()

--- a/src/code/views/download-dialog-view.coffee
+++ b/src/code/views/download-dialog-view.coffee
@@ -34,6 +34,10 @@ module.exports = React.createClass
     s.replace /^\s+|\s+$/, ''
 
   download: (e) ->
+    makeBlobURL = (msg) ->
+      blob = new Blob([msg], {type: 'text/plain'})
+      window.URL.createObjectURL(blob)
+
     if @state.trimmedFilename.length > 0
       json = @props.content.getContent()
       if json and not @state.includeShareInfo
@@ -42,7 +46,7 @@ module.exports = React.createClass
         delete json.isUnshared
         # CODAP moves the keys into its own namespace
         delete json.metadata.shared if json.metadata?.shared?
-      e.target.setAttribute 'href', "data:application/json,#{encodeURIComponent(JSON.stringify json)}"
+      e.target.setAttribute 'href', makeBlobURL(JSON.stringify(json))
       @props.close()
     else
       e.preventDefault()

--- a/src/code/views/url-tab-view.coffee
+++ b/src/code/views/url-tab-view.coffee
@@ -33,7 +33,7 @@ module.exports = React.createClass
   drop: (e) ->
     e.preventDefault()
     if e.dataTransfer
-      droppedUrls = (e.dataTransfer.getData('url') or dataTransfer.getData('text/uri-list') or '').split '\n'
+      droppedUrls = (e.dataTransfer.getData('url') or e.dataTransfer.getData('text/uri-list') or '').split '\n'
       if droppedUrls.length > 1
         @props.client.alert tr "~IMPORT_URL.MULTIPLE_URLS_DROPPED"
       else if droppedUrls.length is 1


### PR DESCRIPTION
These are three small bug fixes.

  * Couldn't download large documents. This was because a data uri was used. Converted to use a Blob uri. PT [#121523735]
  * The "all changes saved" message was no longer displaying when a save completed. The saved state was being overwritten inadvertently. PT [#117561145]
  * Finally a drop of a uri list was not correctly handled.