### PR TITLE
Notify when ready

### DIFF
--- a/src/assets/examples/index.html
+++ b/src/assets/examples/index.html
@@ -23,6 +23,7 @@
       <li><a href="close-file.html">Add Close to the menu.</a></li>
       <li><a href="enable-demo-extension.html">Enable .demo extension</a></li>
       <li><a href="enable-lara-sharing.html">Enable LARA sharing</a></li>
+      <li><a href="splash-screen.html">Splash screen state</a></li>
     </ul>
   </body>
 </html>

--- a/src/assets/examples/splash-screen.html
+++ b/src/assets/examples/splash-screen.html
@@ -1,0 +1,68 @@
+<html>
+  <head>
+    <script src="../js/globals.js"></script>
+    <script src="../js/app.js"></script>
+    <link rel="stylesheet" href="../css/app.css">
+    <style>
+      #state {
+        z-index: 10;
+        position: absolute;
+        background: lightgoldenrodyellow;
+        font-size: 1.5em;
+        left: 200px;
+      }
+      #state:before {
+        content: "State: ";
+      }
+    </style>
+    <title>Examples: Splash screen</title>
+  </head>
+  <body>
+    <div id="state">
+    </div>
+    <div id="wrapper">
+    </div>
+    <script>
+      var options = {
+        app: "example-app",
+        mimeType: "text/plain",
+        appName: "CFM_Demo",
+        appVersion: "0.1",
+        appBuildNum: "1",
+        providers: [
+          {
+            "name": "googleDrive",
+            "clientId": "1095918012594-svs72eqfalasuc4t1p1ps1m8r9b8psso.apps.googleusercontent.com"
+          },
+          {
+            "name": "documentStore",
+            "patch": true
+          }
+        ],
+        ui: {
+          menu: CloudFileManager.DefaultMenu
+        }
+      };
+
+      function setState(state) {
+        document.getElementById("state").innerHTML = state;
+      }
+
+      setState("Showing splash screen");
+
+      CloudFileManager.createFrame(options, "wrapper", function (event) {
+        /**
+         * This will get called both if the app is opened with no file to be downloaded
+         * (i.e. a blank document, no hash in the url), and also if we open something
+         * either from the menu of from the url (e.g. .../examples/splash-screen.html#file=documentStore:7894)
+         * In the latter case, this works because our inner app calls the event callback
+         * in response to an `openedFile` event. (If the event callback were not called,
+         * `ready` would not be called either.)
+         */
+        if (event.type == 'ready') {
+          setState("Splash screen hidden");
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -55,6 +55,8 @@ class CloudFileManager
       @client.openProviderFile providerName, providerParams
     else if hashParams.copyParams
       @client.openCopiedFile hashParams.copyParams
+    else
+      @client.ready()
 
   _createHiddenApp: ->
     anchor = document.createElement("div")

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -495,6 +495,7 @@ class CloudFileManagerClient
         if not @appOptions.wrapFileContent
           content.addMetadata iSharedMetadata
         @_updateState content, metadata, additionalState, hashParams
+        @ready()
 
   _updateState: (content, metadata, additionalState={}, hashParams=null) ->
     state =

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -102,6 +102,9 @@ class CloudFileManagerClient
   connect: ->
     @_event 'connected', {client: @}
 
+  ready: ->
+    @_event 'ready'
+
   listen: (listener) ->
     if listener
       @_listeners.push listener


### PR DESCRIPTION
This adds a client event, `ready`, which is called

1. After the client has connected, if there is nothing left to do (no file to open)
2. After a file has been opened and the app has called the callback

This can be used by the app to know that we're in a ready state and the user can start interacting with the app (hide splash screen, etc.)

Previously, it was not clear from the app perspective whether a file was going to be loaded by the CFM after the initial `connect` event.