### PR TITLE
Allow readonly files to be loaded from url hash

### DIFF
--- a/src/assets/examples/all-providers.html
+++ b/src/assets/examples/all-providers.html
@@ -20,6 +20,7 @@
           "localFile",
           {
             "name": "readOnly",
+            "urlDisplayName": "examples",
             "json": {
               "first-example": "This is the first readonly example",
               "second-example": "This is the second readonly example"

--- a/src/assets/examples/read-only-with-folders.html
+++ b/src/assets/examples/read-only-with-folders.html
@@ -17,6 +17,7 @@
           /* Original map format example */
           {
             "displayName": "Read Only (map)",
+            "urlDisplayName": "readOnly-map",
             "name": "readOnly",
             "json": {
               "First File Example": "This is the first readonly example",
@@ -34,11 +35,12 @@
           /* Original example in array format */
           {
             "displayName": "Read Only (array)",
+            "urlDisplayName": "readOnly-array",
             "name": "readOnly",
             "json": [
               { name: "Third File Example", content: "This is the third readonly example" },
               { name: "Fourth File Example", content: "This is the fourth readonly example" },
-              { name: "Third Folder Example", type: 'folder', 
+              { name: "Third Folder Example", type: 'folder',
                 children: [
                   { name: "Third Folder First File Example", content: "This is the third folder first readonly example" },
                   { name: "Third Folder Second File Example", content: "This is the third folder second readonly example" }
@@ -53,6 +55,7 @@
           /* Remote files in array format */
           {
             "displayName": "Read Only (remote 'src')",
+            "urlDisplayName": "readOnly-remote1",
             "name": "readOnly",
             "alphabetize": true,
             "src": 'https://codap-resources.concord.org/examples/index.json'
@@ -60,6 +63,7 @@
           /* Remote array format */
           {
             "displayName": "Read Only (remote folders)",
+            "urlDisplayName": "readOnly-remote2",
             "name": "readOnly",
             json: [
               {

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -60,6 +60,8 @@ class CloudFileManagerClient
           Provider = allProviders[providerName]
           provider = new Provider providerOptions, @
           @providers[providerName] = provider
+          if provider.urlDisplayName        # also add to here in providers list so we can look it up when parsing url hash
+            @providers[provider.urlDisplayName] = provider
           availableProviders.push provider
         else
           @alert "Unknown provider: #{providerName}"
@@ -549,7 +551,7 @@ class CloudFileManagerClient
       document.title = "#{if name?.length > 0 then name else (tr "~MENUBAR.UNTITLED_DOCUMENT")}#{@appOptions.ui.windowTitleSeparator}#{@appOptions.ui.windowTitleSuffix}"
 
   _getHashParams: (metadata) ->
-    if metadata?.provider?.canOpenSaved() then "#file=#{metadata.provider.name}:#{encodeURIComponent metadata.provider.getOpenSavedParams metadata}" else ""
+    if metadata?.provider?.canOpenSaved() then "#file=#{metadata.provider.urlDisplayName or metadata.provider.name}:#{encodeURIComponent metadata.provider.getOpenSavedParams metadata}" else ""
 
 module.exports =
   CloudFileManagerClientEvent: CloudFileManagerClientEvent

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -49,6 +49,7 @@ class DocumentStoreProvider extends ProviderInterface
     super
       name: DocumentStoreProvider.Name
       displayName: @options.displayName or (tr '~PROVIDER.DOCUMENT_STORE')
+      urlDisplayName: @options.urlDisplayName
       capabilities:
         save: true
         load: true

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -391,6 +391,8 @@ class DocumentStoreProvider extends ProviderInterface
         return if jqXHR.status is 403 # let statusCode handler deal with it
         callback "Unable to rename #{metadata.name}"
 
+  canOpenSaved: -> true
+
   openSaved: (openSavedParams, callback) ->
     metadata = new CloudMetadata
       type: CloudMetadata.File

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -38,6 +38,7 @@ class GoogleDriveProvider extends ProviderInterface
     super
       name: GoogleDriveProvider.Name
       displayName: @options.displayName or (tr '~PROVIDER.GOOGLE_DRIVE')
+      urlDisplayName: @options.urlDisplayName
       capabilities:
         save: true
         load: true

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -167,6 +167,8 @@ class GoogleDriveProvider extends ProviderInterface
     if metadata.providerData?.realTime?.doc?
       metadata.providerData.realTime.doc.close()
 
+  canOpenSaved: -> true
+
   openSaved: (openSavedParams, callback) ->
     metadata = new CloudMetadata
       type: CloudMetadata.File

--- a/src/code/providers/localstorage-provider.coffee
+++ b/src/code/providers/localstorage-provider.coffee
@@ -76,6 +76,8 @@ class LocalStorageProvider extends ProviderInterface
     catch
       callback? 'Unable to rename'
 
+  canOpenSaved: -> true
+
   openSaved: (openSavedParams, callback) ->
     metadata = new CloudMetadata
       name: openSavedParams

--- a/src/code/providers/localstorage-provider.coffee
+++ b/src/code/providers/localstorage-provider.coffee
@@ -10,6 +10,7 @@ class LocalStorageProvider extends ProviderInterface
     super
       name: LocalStorageProvider.Name
       displayName: @options.displayName or (tr '~PROVIDER.LOCAL_STORAGE')
+      urlDisplayName: @options.urlDisplayName
       capabilities:
         save: true
         load: true

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -194,7 +194,7 @@ class ProviderInterface
   close: (metadata, callback) ->
     @_notImplemented 'close'
 
-  canOpenSaved: -> true
+  canOpenSaved: -> false
 
   openSaved: (openSavedParams, callback) ->
     @_notImplemented 'openSaved'

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -144,7 +144,7 @@ class CloudContent
 class ProviderInterface
 
   constructor: (options) ->
-    {@name, @displayName, @capabilities} = options
+    {@name, @displayName, @urlDisplayName, @capabilities} = options
 
   @Available: -> true
 

--- a/src/code/providers/readonly-provider.coffee
+++ b/src/code/providers/readonly-provider.coffee
@@ -57,6 +57,8 @@ class ReadOnlyProvider extends ProviderInterface
       # clone the metadata items so that any changes made to the filename or content in the edit is not cached
       callback null, _.map items, (metadataItem) -> new CloudMetadata metadataItem
 
+  canOpenSaved: -> true
+
   openSaved: (openSavedParams, callback) ->
     metadata = new CloudMetadata
       name: unescape(openSavedParams)

--- a/src/code/providers/readonly-provider.coffee
+++ b/src/code/providers/readonly-provider.coffee
@@ -25,24 +25,22 @@ class ReadOnlyProvider extends ProviderInterface
   @Name: 'readOnly'
 
   load: (metadata, callback) ->
-    @_loadTree (err, tree) ->
-      return callback err if err
-      if metadata and not isArray metadata and metadata.type is CloudMetadata.File
-        if metadata.content?
-          callback null, metadata.content
-          return
-        else if metadata.url?
-          $.ajax
-            dataType: 'json'
-            url: metadata.url
-            success: (data) ->
-              callback null, cloudContentFactory.createEnvelopedCloudContent data
-            error: -> callback "Unable to load '#{metadata.name}'"
-          return
-      if metadata?.name?
+    if metadata and not isArray metadata and metadata.type is CloudMetadata.File
+      if metadata.content?
+        callback null, metadata.content
+        return
+      else if metadata.url?
+        $.ajax
+          dataType: 'json'
+          url: metadata.url
+          success: (data) ->
+            callback null, cloudContentFactory.createEnvelopedCloudContent data
+          error: -> callback "Unable to load '#{metadata.name}'"
+        return
+      else if metadata?.name?
         callback "Unable to load '#{metadata.name}'"
-      else
-        callback "Unable to load specified content"
+    else
+      callback "Unable to load specified content"
 
   list: (metadata, callback) ->
     @_loadTree (err, tree) =>

--- a/src/code/providers/readonly-provider.coffee
+++ b/src/code/providers/readonly-provider.coffee
@@ -12,6 +12,7 @@ class ReadOnlyProvider extends ProviderInterface
     super
       name: ReadOnlyProvider.Name
       displayName: @options.displayName or (tr '~PROVIDER.READ_ONLY')
+      urlDisplayName: @options.urlDisplayName
       capabilities:
         save: false
         load: true


### PR DESCRIPTION
This gives the readOnly provider the capability already found in the other providers, that of modifying the url hash when a file is opened, and loading a file when a url with a file fragment is opened.

This way we can link directly to a static example, using `...#file=examples:some-page`

Additionally, apps can chose what to name the providers in the url hash, and have multiple named providers so the fragment can be   `...#file=demos:some-page`, `...#file=AP-curriculum:some-page` or whatever makes most sense given the language of the project.