### PR TITLE
Add ability to open files at arbitrary urls directly

### DIFF
--- a/src/assets/examples/index.html
+++ b/src/assets/examples/index.html
@@ -24,6 +24,7 @@
       <li><a href="enable-demo-extension.html">Enable .demo extension</a></li>
       <li><a href="enable-lara-sharing.html">Enable LARA sharing</a></li>
       <li><a href="splash-screen.html">Splash screen state</a></li>
+      <li><a href="load-url-query-param.html?url=http://concord-consortium.github.io/codap-data/Climate_Change/Climate-Change-A.json">Load URL query parameter</a></li>
     </ul>
   </body>
 </html>

--- a/src/assets/examples/load-url-query-param.html
+++ b/src/assets/examples/load-url-query-param.html
@@ -1,0 +1,54 @@
+<html>
+  <head>
+    <script src="../js/globals.js"></script>
+    <script src="../js/app.js"></script>
+    <link rel="stylesheet" href="../css/app.css">
+    <title>Examples: All Providers</title>
+  </head>
+  <body>
+    <div id="wrapper">
+    </div>
+    <script>
+      function getQueryVariable(variable) {
+         var query = window.location.search.substring(1);
+         var vars = query.split("&");
+         for (var i=0;i<vars.length;i++) {
+                 var pair = vars[i].split("=");
+                 if(pair[0] == variable){return pair[1];}
+         }
+         return(false);
+      }
+
+      var options = {
+        app: "example-app",
+        mimeType: "text/plain",
+        appName: "CFM_Demo",
+        appVersion: "0.1",
+        appBuildNum: "1",
+        providers: [
+          {
+            "name": "readOnly",
+            "urlDisplayName": "instructions",
+            "json": {
+              "text": "Try loading a this page with a url query parameter, such as .../load-url-query-param.html?url=http://concord-consortium.github.io/codap-data/Climate_Change/Climate-Change-A.json"
+            }
+          }
+        ],
+        ui: {
+          menu: CloudFileManager.DefaultMenu
+        }
+      };
+      CloudFileManager.createFrame(options, "wrapper", function (event) {
+        if (event.type == 'connected') {
+          var client = event.data.client;
+          var urlToLoad = getQueryVariable("url");
+          if (urlToLoad) {
+            client.openUrlFile(urlToLoad);
+          } else {
+            client.openProviderFile("instructions", "text");
+          }
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -51,8 +51,11 @@ class CloudFileManager
     if hashParams.sharedContentId
       @client.openSharedContent hashParams.sharedContentId
     else if hashParams.fileParams
-      [providerName, providerParams] = hashParams.fileParams.split ':'
-      @client.openProviderFile providerName, providerParams
+      if hashParams.fileParams.indexOf("http") is 0
+        @client.openUrlFile hashParams.fileParams
+      else
+        [providerName, providerParams] = hashParams.fileParams.split ':'
+        @client.openProviderFile providerName, providerParams
     else if hashParams.copyParams
       @client.openCopiedFile hashParams.copyParams
     else

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -8,6 +8,7 @@ ReadOnlyProvider = require './providers/readonly-provider'
 GoogleDriveProvider = require './providers/google-drive-provider'
 DocumentStoreProvider = require './providers/document-store-provider'
 LocalFileProvider = require './providers/local-file-provider'
+URLProvider = require './providers/url-provider'
 
 cloudContentFactory = (require './providers/provider-interface').cloudContentFactory
 CloudContent = (require './providers/provider-interface').CloudContent
@@ -228,6 +229,12 @@ class CloudFileManagerClient
           provider.openSaved providerParams, (err, content, metadata) =>
             return @alert(err) if err
             @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata
+
+  openUrlFile: (url) ->
+    urlProvider = new URLProvider()
+    urlProvider.openFileFromUrl url, (err, content, metadata) =>
+      return @alert(err) if err
+      @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata
 
   isSaveInProgress: ->
     @state.saving?
@@ -549,7 +556,12 @@ class CloudFileManagerClient
       document.title = "#{if name?.length > 0 then name else (tr "~MENUBAR.UNTITLED_DOCUMENT")}#{@appOptions.ui.windowTitleSeparator}#{@appOptions.ui.windowTitleSuffix}"
 
   _getHashParams: (metadata) ->
-    if metadata?.provider?.canOpenSaved() then "#file=#{metadata.provider.name}:#{encodeURIComponent metadata.provider.getOpenSavedParams metadata}" else ""
+    if metadata?.provider?.canOpenSaved()
+      "#file=#{metadata.provider.name}:#{encodeURIComponent metadata.provider.getOpenSavedParams metadata}"
+    else if metadata?.provider instanceof URLProvider and
+        window.location.hash.indexOf("#file=http") is 0
+      window.location.hash    # leave it alone
+    else ""
 
 module.exports =
   CloudFileManagerClientEvent: CloudFileManagerClientEvent

--- a/src/code/providers/url-provider.coffee
+++ b/src/code/providers/url-provider.coffee
@@ -1,0 +1,36 @@
+ProviderInterface = (require './provider-interface').ProviderInterface
+cloudContentFactory = (require './provider-interface').cloudContentFactory
+CloudMetadata = (require './provider-interface').CloudMetadata
+
+# This provider gets created by the client when needed to open a url directly.
+# It cannot be added as one of the app's list of providers
+
+class URLProvider extends ProviderInterface
+
+  constructor: (@options = {}, @client) ->
+    super
+      capabilities:
+        save: false
+        load: false
+        list: false
+        remove: false
+        rename: false
+        close: false
+
+  canOpenSaved: -> false
+
+  openFileFromUrl: (url, callback) ->
+    metadata = new CloudMetadata
+      type: CloudMetadata.File
+      url: url
+      parent: null
+      provider: @
+
+    $.ajax
+      dataType: 'json'
+      url: metadata.url
+      success: (data) ->
+        callback null, cloudContentFactory.createEnvelopedCloudContent(data), metadata
+      error: -> callback "Unable to load '#{metadata.name}'"
+
+module.exports = URLProvider


### PR DESCRIPTION
This adds a new provider to load files from remote urls directly.

The app will automatically try to open urls when it sees the url fragment

`#file=http...`

The app can also ask the client to open a url directly through the API, and a CODAP-friendly example of this is added, showing an app that takes a query parameter and uses it to open a remote file.

[#121532705]