### PR TITLE
Refactor for v2 API

### DIFF
--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -25,6 +25,7 @@ class CloudFileManager
       sharedContentId: getHashParam "shared"
       fileParams: getHashParam "file"
       copyParams: getHashParam "copy"
+      documentServer: getQueryParam "documentServer"
       runKey: getQueryParam "runKey"
       runAsGuest: (getQueryParam "runAsGuest") is "true"
     }

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -7,6 +7,7 @@ LocalStorageProvider = require './providers/localstorage-provider'
 ReadOnlyProvider = require './providers/readonly-provider'
 GoogleDriveProvider = require './providers/google-drive-provider'
 DocumentStoreProvider = require './providers/document-store-provider'
+DocumentStoreShareProvider = require './providers/document-store-share-provider'
 LocalFileProvider = require './providers/local-file-provider'
 URLProvider = require './providers/url-provider'
 
@@ -67,13 +68,9 @@ class CloudFileManagerClient
           availableProviders.push provider
         else
           @alert "Unknown provider: #{providerName}"
-    @_setState availableProviders: availableProviders
-
-    # add singleton shareProvider, if it exists
-    for provider in @state.availableProviders
-      if provider.can 'share'
-        @_setState shareProvider: provider
-        break
+    @_setState
+      availableProviders: availableProviders
+      shareProvider: new DocumentStoreShareProvider(@, @providers[DocumentStoreProvider.Name])
 
     @appOptions.ui or= {}
     @appOptions.ui.windowTitleSuffix or= document.title

--- a/src/code/providers/document-store-share-provider.coffee
+++ b/src/code/providers/document-store-share-provider.coffee
@@ -1,0 +1,61 @@
+CloudMetadata = (require './provider-interface').CloudMetadata
+DocumentStoreUrl = require './document-store-url'
+
+#
+# A utility class for providing sharing functionality via the Concord Document Store.
+# Originally, sharing was wrapped into the Provider interface, but since we have no
+# plans to extend sharing support to arbitrary providers like Google Drive, it seems
+# cleaner to break out the sharing functionality into its own class.
+#
+class DocumentStoreShareProvider
+
+  constructor: (@client, @provider) ->
+    @docStoreUrl = new DocumentStoreUrl @client.appOptions.hashParams.documentServer
+
+  loadSharedContent: (id, callback) ->
+    sharedMetadata = new CloudMetadata
+      sharedContentId: id
+      type: CloudMetadata.File
+      overwritable: false
+    @provider.load sharedMetadata, (err, content) ->
+      callback err, content, sharedMetadata
+
+  getSharingMetadata: (shared) ->
+    { _permissions: if shared then 1 else 0 }
+
+  share: (masterContent, sharedContent, metadata, callback) ->
+    # generate runKey if it doesn't already exist as 'shareEditKey'
+    runKey = masterContent.get("shareEditKey") or Math.random().toString(16).substring(2)
+
+    params =
+      runKey: runKey
+
+    # pass sharedDocumentId as 'recordid' query param
+    if masterContent.get("sharedDocumentId")
+      params.recordid = masterContent.get("sharedDocumentId")
+
+    mimeType = 'application/json' # Document Store requires JSON currently
+
+    $.ajax
+      dataType: 'json'
+      type: 'POST'
+      url: @docStoreUrl.saveDocument(params)
+      contentType: mimeType
+      data: pako.deflate sharedContent.getContentAsJSON()
+      processData: false
+      beforeSend: (xhr) ->
+        xhr.setRequestHeader('Content-Encoding', 'deflate')
+      context: @
+      xhrFields:
+        withCredentials: false
+      success: (data) ->
+        # on successful share/save, capture the sharedDocumentId and shareEditKey
+        masterContent.addMetadata
+          sharedDocumentId: data.id
+          shareEditKey: runKey
+        callback null, data.id
+      error: (jqXHR) ->
+        docName = metadata?.filename or 'document'
+        callback "Unable to share '#{docName}'"
+
+module.exports = DocumentStoreShareProvider

--- a/src/code/providers/document-store-url.coffee
+++ b/src/code/providers/document-store-url.coffee
@@ -1,0 +1,47 @@
+#
+# This utility class simplifies working with document store URLs
+#
+
+# default document store URL if client doesn't provide one
+defaultDocStoreUrl = "//document-store.concord.org"
+
+class DocumentStoreUrl
+
+  constructor: (docStoreUrl) ->
+    @docStoreUrl = docStoreUrl or defaultDocStoreUrl
+
+  addParams: (url, params) ->
+    return url unless params
+    kvp = []
+    for key, value of params
+      kvp.push [key, value].map(encodeURI).join "="
+    return url + "?" + kvp.join "&"
+
+  #
+  # Version 1 API
+  #
+  authorize: (params) ->
+    @addParams "#{@docStoreUrl}/user/authenticate", params
+
+  checkLogin: (params) ->
+    @addParams "#{@docStoreUrl}/user/info", params
+
+  listDocuments: (params) ->
+    @addParams "#{@docStoreUrl}/document/all", params
+
+  loadDocument: (params) ->
+    @addParams "#{@docStoreUrl}/document/open", params
+
+  saveDocument: (params) ->
+    @addParams "#{@docStoreUrl}/document/save", params
+
+  patchDocument: (params) ->
+    @addParams "#{@docStoreUrl}/document/patch", params
+
+  deleteDocument: (params) ->
+    @addParams "#{@docStoreUrl}/document/delete", params
+
+  renameDocument: (params) ->
+    @addParams "#{@docStoreUrl}/document/rename", params
+
+module.exports = DocumentStoreUrl


### PR DESCRIPTION
Implement DocumentStoreUrl class
- Move responsibility for knowing/manipulating document store URLs and parameters into its own class
- Support redirecting document store requests via 'documentServer' command line argument
- Fixes [#128108157]

Separate sharing functionality into DocumentStoreShareProvider class