### PR TITLE
Rationalize url param handling; improve error handling

### DIFF
--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -4,7 +4,6 @@ CloudFileManagerUIMenu = (require './ui').CloudFileManagerUIMenu
 CloudFileManagerClient = (require './client').CloudFileManagerClient
 
 getHashParam = require './utils/get-hash-param'
-getQueryParam = require './utils/get-query-param'
 
 class CloudFileManager
 
@@ -26,9 +25,6 @@ class CloudFileManager
       fileParams: getHashParam "file"
       copyParams: getHashParam "copy"
       newInFolderParams: getHashParam "newInFolder"
-      documentServer: getQueryParam "documentServer"
-      runKey: getQueryParam "runKey"
-      runAsGuest: (getQueryParam "runAsGuest") is "true"
     }
 
     @client.setAppOptions @appOptions
@@ -49,22 +45,8 @@ class CloudFileManager
     @client.listen eventCallback
     @client.connect()
 
-    hashParams = @appOptions.hashParams
-    if hashParams.sharedContentId
-      @client.openSharedContent hashParams.sharedContentId
-    else if hashParams.fileParams
-      if hashParams.fileParams.indexOf("http") is 0
-        @client.openUrlFile hashParams.fileParams
-      else
-        [providerName, providerParams] = hashParams.fileParams.split ':'
-        @client.openProviderFile providerName, providerParams
-    else if hashParams.copyParams
-      @client.openCopiedFile hashParams.copyParams
-    else if hashParams.newInFolderParams
-      [providerName, folder] = hashParams.newInFolderParams.split ':'
-      @client.createNewInFolder providerName, folder
-    else
-      @client.ready()
+    # open any initial document (if any specified) and signal ready()
+    @client.processUrlParams()
 
   _createHiddenApp: ->
     anchor = document.createElement("div")

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -261,6 +261,14 @@ class CloudFileManagerClient
         provider.authorize =>
           @openProviderFile providerName providerParams
 
+  confirmAuthorizeAndOpen: (provider, providerParams) ->
+    # trigger authorize() from confirmation dialog to avoid popup blockers
+    @confirm tr("~CONFIRM.AUTHORIZE_OPEN"), =>
+      provider.authorize =>
+        provider.openSaved providerParams, (err, content, metadata) =>
+          return @alert(err) if err
+          @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata
+
   openProviderFile: (providerName, providerParams) ->
     provider = @providers[providerName]
     if provider
@@ -270,6 +278,10 @@ class CloudFileManagerClient
           provider.openSaved providerParams, (err, content, metadata) =>
             return @alert(err, => @ready()) if err
             @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata
+        else
+          @confirmAuthorizeAndOpen(provider, providerParams)
+    else
+      @alert tr("~ALERT.NO_PROVIDER")
 
   openUrlFile: (url) ->
     @urlProvider.openFileFromUrl url, (err, content, metadata) =>

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -135,11 +135,7 @@ class CloudFileManagerClient
     else
       # give providers a chance to process url params
       for provider in @state.availableProviders
-        handleResult = provider.canHandleUrlParams()
-        if handleResult and handleResult.providerName
-          {providerName, providerParams} = handleResult
-          @openProviderFile providerName, providerParams
-          return
+        return if provider.handleUrlParams()
 
       # if no providers handled it, then just signal ready()
       @ready()

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -161,10 +161,9 @@ class DocumentStoreProvider extends ProviderInterface
     else
       null
 
-  canHandleUrlParams: ->
-    if @urlParams.recordid \
-      then { providerName: @name, providerParams: @urlParams.recordid } \
-      else null
+  handleUrlParams: ->
+    if @urlParams.recordid
+      @client.openProviderFile @name, @urlParams.recordid
 
   list: (metadata, callback) ->
     $.ajax

--- a/src/code/providers/document-store-share-provider.coffee
+++ b/src/code/providers/document-store-share-provider.coffee
@@ -10,7 +10,7 @@ DocumentStoreUrl = require './document-store-url'
 class DocumentStoreShareProvider
 
   constructor: (@client, @provider) ->
-    @docStoreUrl = new DocumentStoreUrl @client.appOptions.hashParams.documentServer
+    @docStoreUrl = @provider.docStoreUrl
 
   loadSharedContent: (id, callback) ->
     sharedMetadata = new CloudMetadata

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -183,8 +183,8 @@ class ProviderInterface
       # may seem weird but it means that without an extension specified all files match
       true
 
-  canHandleUrlParams: ->
-    null # by default, no additional URL handling
+  handleUrlParams: ->
+    false # by default, no additional URL handling
 
   dialog: (callback) ->
     @_notImplemented 'dialog'

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -180,6 +180,9 @@ class ProviderInterface
       # may seem weird but it means that without an extension specified all files match
       true
 
+  canHandleUrlParams: ->
+    null # by default, no additional URL handling
+
   dialog: (callback) ->
     @_notImplemented 'dialog'
 

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -154,6 +154,9 @@ class ProviderInterface
   can: (capability) ->
     @capabilities[capability]
 
+  isAuthorizationRequired: ->
+    false
+
   authorized: (callback) ->
     if callback
       callback true

--- a/src/code/providers/url-provider.coffee
+++ b/src/code/providers/url-provider.coffee
@@ -31,6 +31,6 @@ class URLProvider extends ProviderInterface
       url: metadata.url
       success: (data) ->
         callback null, cloudContentFactory.createEnvelopedCloudContent(data), metadata
-      error: -> callback "Unable to load '#{metadata.name}'"
+      error: -> callback "Unable to load document from '#{metadata.url}'"
 
 module.exports = URLProvider

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -62,6 +62,7 @@ module.exports =
 
   "~CONFIRM.OPEN_FILE": "You have unsaved changes. Are you sure you want to open a new document?"
   "~CONFIRM.NEW_FILE": "You have unsaved changes. Are you sure you want to create a new document?"
+  "~CONFIRM.AUTHORIZE_OPEN": "Authorization is required to open the document. Would you like to proceed with authorization?"
   "~CONFIRM.AUTHORIZE_SAVE": "Authorization is required to save the document. Would you like to proceed with authorization?"
   "~CONFIRM.CLOSE_FILE": "You have unsaved changes. Are you sure you want to close the document?"
   "~CONFIRM.REVERT_TO_LAST_OPENED": "Are you sure you want to revert the document to its most recently opened state?"
@@ -88,3 +89,5 @@ module.exports =
 
   "~ALERT_DIALOG.TITLE": "Alert"
   "~ALERT_DIALOG.CLOSE": "Close"
+
+  "~ALERT.NO_PROVIDER": "Could not open the specified document because an appropriate provider is not available."

--- a/src/code/views/alert-dialog-view.coffee
+++ b/src/code/views/alert-dialog-view.coffee
@@ -8,12 +8,16 @@ module.exports = React.createClass
 
   displayName: 'AlertDialogView'
 
+  close: ->
+    @props.close?()
+    @props.callback?()
+
   render: ->
-    (ModalDialog {title: @props.title or (tr '~ALERT_DIALOG.TITLE'), close: @props.close, zIndex: 100},
+    (ModalDialog {title: @props.title or (tr '~ALERT_DIALOG.TITLE'), close: @close, zIndex: 100},
       (div {className: 'alert-dialog'},
         (div {className: 'alert-dialog-message'}, @props.message)
         (div {className: 'buttons'},
-          (button {onClick: @props.close}, tr '~ALERT_DIALOG.CLOSE')
+          (button {onClick: @close}, tr '~ALERT_DIALOG.CLOSE')
         )
       )
     )

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -158,7 +158,7 @@ App = React.createClass
 
       # alert and confirm dialogs can be overlayed on other dialogs
       if @state.alertDialog
-        (AlertDialog {title: @state.alertDialog.title, message: @state.alertDialog.message, close: @closeAlert})
+        (AlertDialog {title: @state.alertDialog.title, message: @state.alertDialog.message, callback: @state.alertDialog.callback, close: @closeAlert})
       if @state.confirmDialog
         (ConfirmDialog {message: @state.confirmDialog.message, callback: @state.confirmDialog.callback, close: @closeConfirm})
     )


### PR DESCRIPTION
(Note: Depends on [PR #33](https://github.com/concord-consortium/cloud-file-manager/pull/33))

In further preparation for the V2 API...

Rationalize URL/hash parameter handling
- hash params are (still) handled by the CloudFileManager (app)
- url params are provider-specific, and so their handling is moved to individual providers (mainly the DocumentStoreProvider at this point)
- hash/url param processing is moved from CloudFileManager.clientConnect() to CloudFileManagerClient.processUrlParams() (which is called from CloudFileManager.clientConnect())
- CloudFileManagerClient.processUrlParams() gives providers a chance to handle hash/url params
- DocumentStoreProvider handles additional recordid url parameter eliminating the need for CODAP to translate it for CFM

Error handling improvements
- allow splash screen to close if an error occurs when opening a document initially (discovered while testing the changes in the previous commits)
- request authorization on failure to open due to lack of authorization
- improve error message upon failure to load from a URL
- signal `ready` on failure to open a file 
