### PR TITLE
Let Google Drive create new files in specific folders

### DIFF
--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -25,6 +25,7 @@ class CloudFileManager
       sharedContentId: getHashParam "shared"
       fileParams: getHashParam "file"
       copyParams: getHashParam "copy"
+      newInFolderParams: getHashParam "newInFolder"
       runKey: getQueryParam "runKey"
       runAsGuest: (getQueryParam "runAsGuest") is "true"
     }
@@ -58,6 +59,9 @@ class CloudFileManager
         @client.openProviderFile providerName, providerParams
     else if hashParams.copyParams
       @client.openCopiedFile hashParams.copyParams
+    else if hashParams.newInFolderParams
+      [providerName, folder] = hashParams.newInFolderParams.split ':'
+      @client.createNewInFolder providerName, folder
     else
       @client.ready()
 

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -255,8 +255,7 @@ class CloudFileManagerClient
     @_event 'newedFile', {content: ""}
 
   setInitialFilename: (filename) ->
-    @state.metadata.name = filename
-    @state.metadata.filename = filename
+    @state.metadata.rename filename
     @save()
 
   isSaveInProgress: ->

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -251,6 +251,13 @@ class CloudFileManagerClient
         providerData:
           id: folder
 
+      @_ui.editInitialFilename()
+
+  setInitialFilename: (filename) ->
+    @state.metadata.name = filename
+    @state.metadata.filename = filename
+    @save()
+
   isSaveInProgress: ->
     @state.saving?
 

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -238,6 +238,19 @@ class CloudFileManagerClient
       return @alert(err) if err
       @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata
 
+  createNewInFolder: (providerName, folder) ->
+    provider = @providers[providerName]
+    if provider and provider.can 'setFolder'
+      if not @state.metadata?
+        @state.metadata = new CloudMetadata
+          type: CloudMetadata.File
+          provider: provider
+
+      @state.metadata.parent = new CloudMetadata
+        type: CloudMetadata.Folder
+        providerData:
+          id: folder
+
   isSaveInProgress: ->
     @state.saving?
 

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -252,6 +252,7 @@ class CloudFileManagerClient
           id: folder
 
       @_ui.editInitialFilename()
+    @_event 'newedFile', {content: ""}
 
   setInitialFilename: (filename) ->
     @state.metadata.name = filename

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -46,6 +46,7 @@ class GoogleDriveProvider extends ProviderInterface
         remove: false
         rename: true
         close: true
+        setFolder: true
 
     @authToken = null
     @user = null

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -216,6 +216,12 @@ class GoogleDriveProvider extends ProviderInterface
         metadata.rename file.title
         metadata.overwritable = file.editable
         metadata.providerData = id: file.id
+        if not metadata.parent? and file.parents?.length > 0
+          metadata.parent = new CloudMetadata
+            type: CloudMetadata.Folder
+            provider: @
+            providerData:
+              id: file.parents[0].id
         xhr = new XMLHttpRequest()
         xhr.open 'GET', file.downloadUrl
         if @authToken

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -65,10 +65,11 @@ class GoogleDriveProvider extends ProviderInterface
   @IMMEDIATE = true
   @SHOW_POPUP = false
 
-  authorized: (@authCallback) ->
-    if @authCallback
+  authorized: (authCallback) ->
+    @authCallback = authCallback unless not authCallback?
+    if authCallback
       if @authToken
-        @authCallback true
+        authCallback true
       else
         @authorize GoogleDriveProvider.IMMEDIATE
     else

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -194,6 +194,9 @@ class ProviderInterface
   close: (metadata, callback) ->
     @_notImplemented 'close'
 
+  setFolder: (metadata) ->
+    @_notImplemented 'setFolder'
+
   canOpenSaved: -> false
 
   openSaved: (openSavedParams, callback) ->

--- a/src/code/ui.coffee
+++ b/src/code/ui.coffee
@@ -162,6 +162,9 @@ class CloudFileManagerUI
   hideBlockingModal: ->
     @listenerCallback new CloudFileManagerUIEvent 'hideBlockingModal'
 
+  editInitialFilename: ->
+    @listenerCallback new CloudFileManagerUIEvent 'editInitialFilename'
+
   alertDialog: (message, title, callback) ->
     @listenerCallback new CloudFileManagerUIEvent 'showAlertDialog',
       title: title

--- a/src/code/ui.coffee
+++ b/src/code/ui.coffee
@@ -91,6 +91,7 @@ class CloudFileManagerUI
 
   constructor: (@client)->
     @menu = null
+    @listenerCallbacks = []
 
   init: (options) ->
     options = options or {}
@@ -101,7 +102,12 @@ class CloudFileManagerUI
       @menu = new CloudFileManagerUIMenu options, @client
 
   # for React to listen for dialog changes
-  listen: (@listenerCallback) ->
+  listen: (callback) ->
+    @listenerCallbacks.push callback
+
+  listenerCallback: (evt) ->
+    for callback in @listenerCallbacks
+      callback evt
 
   appendMenuItem: (item) ->
     @listenerCallback new CloudFileManagerUIEvent 'appendMenuItem', item

--- a/src/code/views/menu-bar-view.coffee
+++ b/src/code/views/menu-bar-view.coffee
@@ -7,6 +7,13 @@ module.exports = React.createClass
 
   displayName: 'MenuBar'
 
+  componentWillMount: ->
+    @props.client._ui.listen (event) =>
+      switch event.type
+        when 'editInitialFilename'
+          @setState editingFilename: true
+          setTimeout (=> @focusFilename()), 10
+
   getFilename: (props) ->
     if props.filename?.length > 0 then props.filename else (tr "~MENUBAR.UNTITLED_DOCUMENT")
 

--- a/src/code/views/menu-bar-view.coffee
+++ b/src/code/views/menu-bar-view.coffee
@@ -11,7 +11,9 @@ module.exports = React.createClass
     @props.client._ui.listen (event) =>
       switch event.type
         when 'editInitialFilename'
-          @setState editingFilename: true
+          @setState
+            editingFilename: true
+            editingInitialFilename: true
           setTimeout (=> @focusFilename()), 10
 
   getFilename: (props) ->
@@ -26,6 +28,7 @@ module.exports = React.createClass
       filename: @getFilename @props
       editableFilename: @getEditableFilename @props
       initialEditableFilename: @getEditableFilename @props
+      editingInitialFilename: false
 
   componentWillReceiveProps: (nextProps) ->
     @setState
@@ -36,7 +39,9 @@ module.exports = React.createClass
   filenameClicked: (e) ->
     e.preventDefault()
     e.stopPropagation()
-    @setState editingFilename: true
+    @setState
+      editingFilename: true
+      editingInitialFilename: false
     setTimeout (=> @focusFilename()), 10
 
   filenameChanged: ->
@@ -62,7 +67,10 @@ module.exports = React.createClass
   rename: ->
     filename = @state.editableFilename.replace /^\s+|\s+$/, ''
     if filename.length > 0
-      @props.client.rename @props.client.state.metadata, filename
+      if @state.editingInitialFilename
+        @props.client.setInitialFilename filename
+      else
+        @props.client.rename @props.client.state.metadata, filename
       @setState
         editingFilename: false
         filename: filename


### PR DESCRIPTION
This adds a new url hash param, `newInFolder={provider}:{folder-id}`, which signals that the app should initialize a blank doc and automatically save it back to the provider, under the correct folder.

This is used by the Google Drive API to allow a user to click on the New button within a folder, and have the file be saved back there. (This also works from the home folder, naturally.)

When the doc is first opened, the filename input at the top is selected and focused, allowing the user to immediately name their document.