### PR TITLE
Extensions and mime types

### DIFF
--- a/src/assets/examples/all-providers.html
+++ b/src/assets/examples/all-providers.html
@@ -12,6 +12,7 @@
       var options = {
         app: "example-app",
         mimeType: "text/plain",
+        readableMimeTypes: ["application/json"],
         extension: "txt",
         readableExtensions: ["json", ""],
         appName: "CFM_Demo",

--- a/src/assets/examples/all-providers.html
+++ b/src/assets/examples/all-providers.html
@@ -13,6 +13,7 @@
         app: "example-app",
         mimeType: "text/plain",
         extension: "txt",
+        readableExtensions: ["json", ""],
         appName: "CFM_Demo",
         appVersion: "0.1",
         appBuildNum: "1",

--- a/src/assets/examples/all-providers.html
+++ b/src/assets/examples/all-providers.html
@@ -12,6 +12,7 @@
       var options = {
         app: "example-app",
         mimeType: "text/plain",
+        extension: "txt",
         appName: "CFM_Demo",
         appVersion: "0.1",
         appBuildNum: "1",
@@ -23,7 +24,7 @@
             "urlDisplayName": "examples",
             "json": {
               "first-example": "This is the first readonly example",
-              "second-example": "This is the second readonly example"
+              "second-example.txt": "This is the second readonly example"
             }
           },
           {

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -48,6 +48,8 @@ class CloudFileManagerClient
 
     # preset the extension if Available
     CloudMetadata.Extension = @appOptions.extension
+    CloudMetadata.ReadableExtensions = @appOptions.readableExtensions or []
+    if CloudMetadata.Extension then CloudMetadata.ReadableExtensions.push CloudMetadata.Extension
 
     # check the providers
     availableProviders = []

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -51,12 +51,16 @@ class CloudFileManagerClient
     CloudMetadata.ReadableExtensions = @appOptions.readableExtensions or []
     if CloudMetadata.Extension then CloudMetadata.ReadableExtensions.push CloudMetadata.Extension
 
+    readableMimetypes = @appOptions.readableMimeTypes or []
+    readableMimetypes.push @appOptions.mimeType
+
     # check the providers
     availableProviders = []
     for provider in @appOptions.providers
       [providerName, providerOptions] = if isString provider then [provider, {}] else [provider.name, provider]
       # merge in other options as needed
       providerOptions.mimeType ?= @appOptions.mimeType
+      providerOptions.readableMimetypes = readableMimetypes
       if not providerName
         @alert "Invalid provider spec - must either be string or object with name property"
       else

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -376,7 +376,7 @@ class DocumentStoreProvider extends ProviderInterface
       url: renameDocumentUrl
       data:
         recordid: metadata.providerData.id
-        newRecordname: metadata.withExtension newName
+        newRecordname: CloudMetadata.withExtension newName
       context: @
       xhrFields:
         withCredentials: true

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -53,6 +53,7 @@ class GoogleDriveProvider extends ProviderInterface
     if not @clientId
       throw new Error 'Missing required clientId in googleDrive provider options'
     @mimeType = @options.mimeType or "text/plain"
+    @readableMimetypes = @options.readableMimetypes
     @useRealTimeAPI = @options.useRealTimeAPI or false
     if @useRealTimeAPI
       @mimeType += '+cfm_realtime'
@@ -119,8 +120,9 @@ class GoogleDriveProvider extends ProviderInterface
 
   list: (metadata, callback) ->
     @_loadedGAPI =>
+      mimeTypesQuery = ("(mimeType = '#{mimeType}')" for mimeType in @readableMimetypes).join " or "
       request = gapi.client.drive.files.list
-        q: query = "((mimeType = '#{@mimeType}') or (mimeType = 'application/vnd.google-apps.folder')) and '#{if metadata then metadata.providerData.id else 'root'}' in parents"
+        q: query = "(#{mimeTypesQuery} or (mimeType = 'application/vnd.google-apps.folder')) and '#{if metadata then metadata.providerData.id else 'root'}' in parents"
       request.execute (result) =>
         return callback('Unable to list files') if not result
         list = []

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -155,7 +155,7 @@ class GoogleDriveProvider extends ProviderInterface
       request = gapi.client.drive.files.patch
         fileId: metadata.providerData.id
         resource:
-          title: metadata.withExtension newName
+          title: CloudMetadata.withExtension newName
       request.execute (result) ->
         if result?.error
           callback? result.error

--- a/src/code/providers/localstorage-provider.coffee
+++ b/src/code/providers/localstorage-provider.coffee
@@ -69,7 +69,7 @@ class LocalStorageProvider extends ProviderInterface
   rename: (metadata, newName, callback) ->
     try
       content = window.localStorage.getItem @_getKey metadata.filename
-      window.localStorage.setItem @_getKey(metadata.withExtension newName), content
+      window.localStorage.setItem @_getKey(CloudMetadata.withExtension newName), content
       window.localStorage.removeItem @_getKey(metadata.filename)
       metadata.rename newName
       callback null, metadata

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -25,7 +25,7 @@ class CloudMetadata
     if keepOriginalExtension and ~name.indexOf(".")
       return name
     extension = CloudMetadata.Extension or defaultExtension
-    if extension? and name.substr(-extension.length) isnt extension
+    if extension? and name.substr(-extension.length+1) isnt ".#{extension}"
       name + "." + extension
     else
       name
@@ -46,7 +46,7 @@ class CloudMetadata
     @filename = @name
     if @name?.substr? and CloudMetadata.Extension? and @type is CloudMetadata.File
       extLen = CloudMetadata.Extension.length
-      @name = @name.substr(0, @name.length - (extLen+1)) if @name.substr(-extLen) is CloudMetadata.Extension
+      @name = @name.substr(0, @name.length - (extLen+1)) if @name.substr(-extLen+1) is ".#{CloudMetadata.Extension}"
       @filename = CloudMetadata.withExtension @name, null, true
 
 # singleton that can create CloudContent wrapped with global options

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -168,8 +168,12 @@ class ProviderInterface
     defaultComponent
 
   matchesExtension: (name) ->
-    if CloudMetadata.Extension?
-      name.substr(-CloudMetadata.Extension.length) is CloudMetadata.Extension
+    if CloudMetadata.ReadableExtensions? and CloudMetadata.ReadableExtensions.length > 0
+      for extension in CloudMetadata.ReadableExtensions
+        return true if name.substr(-extension.length) is extension
+        if extension is ""
+          return true if !~name.indexOf(".")
+      return false
     else
       # may seem weird but it means that without an extension specified all files match
       true

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -21,6 +21,13 @@ class CloudMetadata
     # for now mapping is 1-to-1 defaulting to 'file'
     iType or @File
 
+  @withExtension: (name, defaultExtension) ->
+    extension = CloudMetadata.Extension or defaultExtension
+    if extension? and name.substr(-extension.length) isnt extension
+      name + "." + extension
+    else
+      name
+
   path: ->
     _path = []
     parent = @parent
@@ -33,18 +40,12 @@ class CloudMetadata
     @name = newName
     @_updateFilename()
 
-  withExtension: (name) ->
-    if CloudMetadata.Extension? and name.substr(-CloudMetadata.Extension.length) isnt CloudMetadata.Extension
-      name + CloudMetadata.Extension
-    else
-      name
-
   _updateFilename: ->
     @filename = @name
     if @name?.substr? and CloudMetadata.Extension? and @type is CloudMetadata.File
       extLen = CloudMetadata.Extension.length
-      @name = @name.substr(0, @name.length - extLen) if @name.substr(-extLen) is CloudMetadata.Extension
-      @filename = @withExtension @name
+      @name = @name.substr(0, @name.length - (extLen+1)) if @name.substr(-extLen) is CloudMetadata.Extension
+      @filename = CloudMetadata.withExtension @name
 
 # singleton that can create CloudContent wrapped with global options
 class CloudContentFactory

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -21,7 +21,9 @@ class CloudMetadata
     # for now mapping is 1-to-1 defaulting to 'file'
     iType or @File
 
-  @withExtension: (name, defaultExtension) ->
+  @withExtension: (name, defaultExtension, keepOriginalExtension) ->
+    if keepOriginalExtension and ~name.indexOf(".")
+      return name
     extension = CloudMetadata.Extension or defaultExtension
     if extension? and name.substr(-extension.length) isnt extension
       name + "." + extension
@@ -45,7 +47,7 @@ class CloudMetadata
     if @name?.substr? and CloudMetadata.Extension? and @type is CloudMetadata.File
       extLen = CloudMetadata.Extension.length
       @name = @name.substr(0, @name.length - (extLen+1)) if @name.substr(-extLen) is CloudMetadata.Extension
-      @filename = CloudMetadata.withExtension @name
+      @filename = CloudMetadata.withExtension @name, null, true
 
 # singleton that can create CloudContent wrapped with global options
 class CloudContentFactory

--- a/src/code/views/download-dialog-view.coffee
+++ b/src/code/views/download-dialog-view.coffee
@@ -10,7 +10,7 @@ module.exports = React.createClass
   displayName: 'DownloadDialogView'
 
   getInitialState: ->
-    filename = "#{@props.filename or (tr "~MENUBAR.UNTITLED_DOCUMENT")}#{CloudMetadata.Extension or '.json'}"
+    filename = CloudMetadata.withExtension(@props.filename or (tr "~MENUBAR.UNTITLED_DOCUMENT"), 'json')
     includeShareInfo = false
     state =
       filename: filename


### PR DESCRIPTION
This improves current extension and mimeType handing by

1. Allowing option arrays of additional extensions/mimeTypes to filter on (which should allow us to re-incorporate the extension option in CODAP, as we can now include legacy formats)
2. Not overwriting existing extensions when we open a readable file from a remote location
3. Adding the main extension to downloaded files, but not duplicating it when it is already there