### PR TITLE
Concord cloud deprecation

### DIFF
--- a/src/assets/examples/deprecate-phase-one.html
+++ b/src/assets/examples/deprecate-phase-one.html
@@ -1,0 +1,58 @@
+<html>
+  <head>
+    <script src="../js/globals.js"></script>
+    <script src="../js/app.js"></script>
+    <link rel="stylesheet" href="../css/app.css">
+    <title>Examples: Depreacate - Phase One</title>
+  </head>
+  <body>
+    <div id="wrapper">
+    </div>
+    <script>
+      var options = {
+        app: "example-app",
+        mimeType: "text/plain",
+        readableMimeTypes: ["application/json"],
+        extension: "txt",
+        readableExtensions: ["json", ""],
+        appName: "CFM_Demo",
+        appVersion: "0.1",
+        appBuildNum: "1",
+        providers: [
+          "localStorage",
+          "localFile",
+          {
+            "name": "readOnly",
+            "urlDisplayName": "examples",
+            "json": {
+              "first-example": "This is the first readonly example",
+              "second-example.txt": "This is the second readonly example"
+            }
+          },
+          {
+            "name": "googleDrive",
+            "clientId": "1095918012594-svs72eqfalasuc4t1p1ps1m8r9b8psso.apps.googleusercontent.com"
+          },
+          {
+            "name": "documentStore",
+            "patch": true,
+            "deprecationPhase": 1
+          }
+        ],
+        ui: {
+          menu: CloudFileManager.DefaultMenu,
+          menuBar: {
+            info: "Deprecate: Phase One",
+            help: "http://lmgtfy.com/"
+          }
+        }
+      };
+      CloudFileManager.createFrame(options, "wrapper", function (event) {
+        if (event.type == 'connected') {
+          var client = event.data.client;
+          client.insertMenuItemAfter('openFileDialog', {"name": "Import data...", action: client.importDataDialog.bind(client)});
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/assets/examples/deprecate-phase-three.html
+++ b/src/assets/examples/deprecate-phase-three.html
@@ -1,0 +1,58 @@
+<html>
+  <head>
+    <script src="../js/globals.js"></script>
+    <script src="../js/app.js"></script>
+    <link rel="stylesheet" href="../css/app.css">
+    <title>Examples: Depreacate - Phase One</title>
+  </head>
+  <body>
+    <div id="wrapper">
+    </div>
+    <script>
+      var options = {
+        app: "example-app",
+        mimeType: "text/plain",
+        readableMimeTypes: ["application/json"],
+        extension: "txt",
+        readableExtensions: ["json", ""],
+        appName: "CFM_Demo",
+        appVersion: "0.1",
+        appBuildNum: "1",
+        providers: [
+          "localStorage",
+          "localFile",
+          {
+            "name": "readOnly",
+            "urlDisplayName": "examples",
+            "json": {
+              "first-example": "This is the first readonly example",
+              "second-example.txt": "This is the second readonly example"
+            }
+          },
+          {
+            "name": "googleDrive",
+            "clientId": "1095918012594-svs72eqfalasuc4t1p1ps1m8r9b8psso.apps.googleusercontent.com"
+          },
+          {
+            "name": "documentStore",
+            "patch": true,
+            "deprecationPhase": 3
+          }
+        ],
+        ui: {
+          menu: CloudFileManager.DefaultMenu,
+          menuBar: {
+            info: "Deprecate: Phase Three",
+            help: "http://lmgtfy.com/"
+          }
+        }
+      };
+      CloudFileManager.createFrame(options, "wrapper", function (event) {
+        if (event.type == 'connected') {
+          var client = event.data.client;
+          client.insertMenuItemAfter('openFileDialog', {"name": "Import data...", action: client.importDataDialog.bind(client)});
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/assets/examples/deprecate-phase-two.html
+++ b/src/assets/examples/deprecate-phase-two.html
@@ -1,0 +1,58 @@
+<html>
+  <head>
+    <script src="../js/globals.js"></script>
+    <script src="../js/app.js"></script>
+    <link rel="stylesheet" href="../css/app.css">
+    <title>Examples: Depreacate - Phase One</title>
+  </head>
+  <body>
+    <div id="wrapper">
+    </div>
+    <script>
+      var options = {
+        app: "example-app",
+        mimeType: "text/plain",
+        readableMimeTypes: ["application/json"],
+        extension: "txt",
+        readableExtensions: ["json", ""],
+        appName: "CFM_Demo",
+        appVersion: "0.1",
+        appBuildNum: "1",
+        providers: [
+          "localStorage",
+          "localFile",
+          {
+            "name": "readOnly",
+            "urlDisplayName": "examples",
+            "json": {
+              "first-example": "This is the first readonly example",
+              "second-example.txt": "This is the second readonly example"
+            }
+          },
+          {
+            "name": "googleDrive",
+            "clientId": "1095918012594-svs72eqfalasuc4t1p1ps1m8r9b8psso.apps.googleusercontent.com"
+          },
+          {
+            "name": "documentStore",
+            "patch": true,
+            "deprecationPhase": 2
+          }
+        ],
+        ui: {
+          menu: CloudFileManager.DefaultMenu,
+          menuBar: {
+            info: "Deprecate: Phase Two",
+            help: "http://lmgtfy.com/"
+          }
+        }
+      };
+      CloudFileManager.createFrame(options, "wrapper", function (event) {
+        if (event.type == 'connected') {
+          var client = event.data.client;
+          client.insertMenuItemAfter('openFileDialog', {"name": "Import data...", action: client.importDataDialog.bind(client)});
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/assets/examples/index.html
+++ b/src/assets/examples/index.html
@@ -28,6 +28,7 @@
       <li><a href="load-url-query-param.html?url=http://concord-consortium.github.io/codap-data/Climate_Change/Climate-Change-A.json">Load URL query parameter</a></li>
       <li><a href="deprecate-phase-one.html">Deprecate: Phase One</a></li>
       <li><a href="deprecate-phase-two.html">Deprecate: Phase Two</a></li>
+      <li><a href="deprecate-phase-three.html">Deprecate: Phase Three</a></li>
     </ul>
   </body>
 </html>

--- a/src/assets/examples/index.html
+++ b/src/assets/examples/index.html
@@ -26,6 +26,8 @@
       <li><a href="lara-provider.html">LARA provider</a></li>
       <li><a href="splash-screen.html">Splash screen state</a></li>
       <li><a href="load-url-query-param.html?url=http://concord-consortium.github.io/codap-data/Climate_Change/Climate-Change-A.json">Load URL query parameter</a></li>
+      <li><a href="deprecate-phase-one.html">Deprecate: Phase One</a></li>
+      <li><a href="deprecate-phase-two.html">Deprecate: Phase Two</a></li>
     </ul>
   </body>
 </html>

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -192,6 +192,7 @@ class CloudFileManagerClient
         @_closeCurrentFile()
         @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata
         callback? content, metadata
+        metadata.provider.fileOpened content, metadata
     else
       @openFileDialog callback
 
@@ -265,6 +266,7 @@ class CloudFileManagerClient
         provider.openSaved providerParams, (err, content, metadata) =>
           return @alert(err) if err
           @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata
+          provider.fileOpened content, metadata
 
   openProviderFile: (providerName, providerParams) ->
     provider = @providers[providerName]
@@ -275,6 +277,7 @@ class CloudFileManagerClient
           provider.openSaved providerParams, (err, content, metadata) =>
             return @alert(err, => @ready()) if err
             @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata
+            provider.fileOpened content, metadata
         else
           @confirmAuthorizeAndOpen(provider, providerParams)
     else
@@ -567,7 +570,10 @@ class CloudFileManagerClient
       history.pushState { originalUrl: window.location.href }, '', url
 
   confirm: (message, callback) ->
-    @_ui.confirmDialog message, callback
+    @confirmDialog { message: message, callback: callback }
+
+  confirmDialog: (params) ->
+    @_ui.confirmDialog params
 
   alert: (message, title=null, callback) ->
     @_ui.alertDialog message, (title or tr "~CLIENT_ERROR.TITLE"), callback

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -164,6 +164,14 @@ class DocumentStoreProvider extends ProviderInterface
     else
       null
 
+  filterTabComponent: (capability, defaultComponent) ->
+    # allow the save elsewhere button to hide the document provider tab in save
+    if capability is 'save' and @disableForNextSave
+      @disableForNextSave = false
+      null
+    else
+      defaultComponent
+
   handleUrlParams: ->
     if @urlParams.recordid
       @client.openProviderFile @name, @urlParams.recordid
@@ -356,6 +364,7 @@ class DocumentStoreProvider extends ProviderInterface
       yesTitle: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_ELSEWHERE'
       noTitle: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_DO_IT_LATER'
       callback: =>
+        @disableForNextSave = true
         @client.saveFileAsDialog content
       rejectCallback: =>
         if deprecationPhase > 1

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -67,6 +67,11 @@ class DocumentStoreProvider extends ProviderInterface
 
     @savedContent = new PatchableContent(@options.patchObjectHash)
 
+    @deprecationMessages = [
+      tr '~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_1'
+      tr '~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_2'
+    ]
+
   @Name: 'documentStore'
 
   # if a runKey is specified, we don't need to authenticate at all
@@ -171,6 +176,11 @@ class DocumentStoreProvider extends ProviderInterface
       null
     else
       defaultComponent
+
+  onProviderTabSelected: (capability) ->
+    # only show alert dialog on save when deprecation is in effect
+    return unless capability is 'save' and @options.deprecationPhase > 0
+    @client.alert @deprecationMessages[@options.deprecationPhase-1], (tr '~CONCORD_CLOUD_DEPRECATION.ALERT_SAVE_TITLE')
 
   handleUrlParams: ->
     if @urlParams.recordid
@@ -354,13 +364,9 @@ class DocumentStoreProvider extends ProviderInterface
   fileOpened: (content, metadata) ->
     deprecationPhase = @options.deprecationPhase or 0
     return if not deprecationPhase
-    deprecationMessages = [
-      tr '~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_1'
-      tr '~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_2'
-    ]
     @client.confirmDialog {
       title: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_TITLE'
-      message: deprecationMessages[deprecationPhase-1]
+      message: @deprecationMessages[deprecationPhase-1]
       yesTitle: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_ELSEWHERE'
       noTitle: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_DO_IT_LATER'
       callback: =>

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -178,26 +178,19 @@ class DocumentStoreProvider extends ProviderInterface
     else
       @options.deprecationPhase < 3
 
-  deprecationMessage: (capability) ->
-    messages = switch capability
-      when 'save'
-        [
-          tr '~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_1'
-          tr '~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_2'
-        ]
-      else
-        [
-          tr '~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_1'
-          tr '~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_2'
-        ]
+  deprecationMessage: ->
+    messages = [
+      tr '~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_1'
+      tr '~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_2'
+    ]
     if @options.deprecationPhase > 0 and @options.deprecationPhase <= messages.length
       messages[@options.deprecationPhase - 1]
     else
       null
 
   onProviderTabSelected: (capability) ->
-    if capability in ['save', 'list'] and @deprecationMessage(capability)
-      @client.alert @deprecationMessage(capability), (tr '~CONCORD_CLOUD_DEPRECATION.ALERT_SAVE_TITLE')
+    if capability is 'save' and @deprecationMessage()
+      @client.alert @deprecationMessage(), (tr '~CONCORD_CLOUD_DEPRECATION.ALERT_SAVE_TITLE')
 
   handleUrlParams: ->
     if @urlParams.recordid
@@ -383,7 +376,7 @@ class DocumentStoreProvider extends ProviderInterface
     return if not deprecationPhase
     @client.confirmDialog {
       title: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_TITLE'
-      message: @deprecationMessage('save')
+      message: @deprecationMessage()
       yesTitle: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_ELSEWHERE'
       noTitle: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_DO_IT_LATER'
       callback: =>

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -219,6 +219,9 @@ class ProviderInterface
   getOpenSavedParams: (metadata) ->
     @_notImplemented 'getOpenSavedParams'
 
+  fileOpened: ->
+    # do nothing by default
+
   _notImplemented: (methodName) ->
     # this uses a browser alert instead of client.alert because this is just here for debugging
     alert "#{methodName} not implemented for #{@name} provider"

--- a/src/code/ui.coffee
+++ b/src/code/ui.coffee
@@ -177,10 +177,8 @@ class CloudFileManagerUI
       message: message
       callback: callback
 
-  confirmDialog: (message, callback) ->
-    @listenerCallback new CloudFileManagerUIEvent 'showConfirmDialog',
-      message: message
-      callback: callback
+  confirmDialog: (params) ->
+    @listenerCallback new CloudFileManagerUIEvent 'showConfirmDialog', params
 
   _showProviderDialog: (action, title, callback) ->
     @listenerCallback new CloudFileManagerUIEvent 'showProviderDialog',

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -29,7 +29,7 @@ module.exports =
   "~PROVIDER.LOCAL_STORAGE": "Local Storage"
   "~PROVIDER.READ_ONLY": "Read Only"
   "~PROVIDER.GOOGLE_DRIVE": "Google Drive"
-  "~PROVIDER.DOCUMENT_STORE": "Document Store"
+  "~PROVIDER.DOCUMENT_STORE": "Concord Cloud"
   "~PROVIDER.LOCAL_FILE": "Local File"
 
   "~FILE_STATUS.SAVING": "Saving..."
@@ -106,9 +106,9 @@ module.exports =
     " Please save your documents to another location as soon as possible."
   "~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_2":
     "The Concord Cloud is closing down." +
-    " This document can no longer be saved to the Concord Cloud." +
-    " After January 1st you will not be able to open this document from the Concord Cloud." +
-    " Please save this document to another location."
+    " Documents can no longer be saved to the Concord Cloud." +
+    " After January 1st you will not be able to open documents from the Concord Cloud." +
+    " Please save your documents to another location as soon as possible."
   "~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_ELSEWHERE": "Save Elsewhere"
   "~CONCORD_CLOUD_DEPRECATION.CONFIRM_DO_IT_LATER": "I'll do it later"
   "~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_1":

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -96,3 +96,28 @@ module.exports =
   "~ALERT_DIALOG.CLOSE": "Close"
 
   "~ALERT.NO_PROVIDER": "Could not open the specified document because an appropriate provider is not available."
+
+  "~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_TITLE": "Concord Cloud Alert"
+  "~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_1":
+    "The Concord Cloud is closing down." +
+    " On November 1st you will no longer be able to save to the Concord Cloud." +
+    " On January 1st you will not be able to open documents from the Concord Cloud." +
+    " Please save your documents to another location as soon as possible."
+  "~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_2":
+    "The Concord Cloud is closing down." +
+    " This document can no longer be saved to the Concord Cloud." +
+    " After January 1st you will not be able to open this document from the Concord Cloud." +
+    " Please save this document to another location."
+  "~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_ELSEWHERE": "Save Elsewhere"
+  "~CONCORD_CLOUD_DEPRECATION.CONFIRM_DO_IT_LATER": "I'll do it later"
+  "~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_1":
+    "The Concord Cloud is closing down." +
+    " On November 1st you will no longer be able to save to the Concord Cloud." +
+    " On January 1st you will not be able to open documents from the Concord Cloud." +
+    " Please save this document to another location as soon as possible."
+  "~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_2":
+    "The Concord Cloud is closing down." +
+    " You can no longer save this document to the Concord Cloud." +
+    " On January 1st you will not be able to open this document from the Concord Cloud." +
+    " Please save this document to another location."
+

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -98,6 +98,7 @@ module.exports =
   "~ALERT.NO_PROVIDER": "Could not open the specified document because an appropriate provider is not available."
 
   "~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_TITLE": "Concord Cloud Alert"
+  "~CONCORD_CLOUD_DEPRECATION.ALERT_SAVE_TITLE": "Concord Cloud Alert"
   "~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_1":
     "The Concord Cloud is closing down." +
     " On November 1st you will no longer be able to save to the Concord Cloud." +

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -99,26 +99,33 @@ module.exports =
 
   "~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_TITLE": "Concord Cloud Alert"
   "~CONCORD_CLOUD_DEPRECATION.ALERT_SAVE_TITLE": "Concord Cloud Alert"
-  "~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_1":
-    "The Concord Cloud is closing down." +
-    " On November 1st you will no longer be able to save to the Concord Cloud." +
-    " On January 1st you will not be able to open documents from the Concord Cloud." +
-    " Please save your documents to another location as soon as possible."
-  "~CONCORD_CLOUD_DEPRECATION.OPEN_PHASE_2":
-    "The Concord Cloud is closing down." +
-    " Documents can no longer be saved to the Concord Cloud." +
-    " After January 1st you will not be able to open documents from the Concord Cloud." +
-    " Please save your documents to another location as soon as possible."
   "~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_ELSEWHERE": "Save Elsewhere"
   "~CONCORD_CLOUD_DEPRECATION.CONFIRM_DO_IT_LATER": "I'll do it later"
-  "~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_1":
-    "The Concord Cloud is closing down." +
-    " On November 1st you will no longer be able to save to the Concord Cloud." +
-    " On January 1st you will not be able to open documents from the Concord Cloud." +
-    " Please save this document to another location as soon as possible."
-  "~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_2":
-    "The Concord Cloud is closing down." +
-    " You can no longer save this document to the Concord Cloud." +
-    " On January 1st you will not be able to open this document from the Concord Cloud." +
-    " Please save this document to another location."
-
+  "~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_1": """
+      <div style="text-align: left">
+        <strong>The Concord Cloud is shutting down soon!</strong>
+        <p>
+          <ul>
+            <li>Nov. 1: Saving to the Concord Cloud will be disabled.</li>
+            <li>Jan. 1: Opening from the Concord Cloud will be disabled.</li>
+          </ul>
+        </p>
+        <p>
+          Please save your documents to another location as soon as possible.
+        </p>
+      </div>
+    """
+  "~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_2": """
+      <div style="text-align: left">
+        <strong>The Concord Cloud is shutting down soon!</strong>
+        <p>
+          <ul>
+            <li>Nov. 1: Saving to the Concord Cloud was disabled.</li>
+            <li>Jan. 1: Opening from the Concord Cloud will be disabled.</li>
+          </ul>
+        </p>
+        <p>
+          Please save your documents to another location as soon as possible.
+        </p>
+      </div>
+    """

--- a/src/code/views/alert-dialog-view.coffee
+++ b/src/code/views/alert-dialog-view.coffee
@@ -13,7 +13,7 @@ module.exports = React.createClass
     @props.callback?()
 
   render: ->
-    (ModalDialog {title: @props.title or (tr '~ALERT_DIALOG.TITLE'), close: @close, zIndex: 100},
+    (ModalDialog {title: @props.title or (tr '~ALERT_DIALOG.TITLE'), close: @close, zIndex: 500},
       (div {className: 'alert-dialog'},
         (div {className: 'alert-dialog-message'}, @props.message)
         (div {className: 'buttons'},

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -164,7 +164,7 @@ App = React.createClass
       if @state.alertDialog
         (AlertDialog {title: @state.alertDialog.title, message: @state.alertDialog.message, callback: @state.alertDialog.callback, close: @closeAlert})
       if @state.confirmDialog
-        (ConfirmDialog {message: @state.confirmDialog.message, callback: @state.confirmDialog.callback, close: @closeConfirm})
+        (ConfirmDialog _.merge {}, @state.confirmDialog, { close: @closeConfirm })
     )
 
   render: ->

--- a/src/code/views/confirm-dialog-view.coffee
+++ b/src/code/views/confirm-dialog-view.coffee
@@ -12,13 +12,17 @@ module.exports = React.createClass
     @props.callback?()
     @props.close()
 
+  reject: ->
+    @props.rejectCallback?()
+    @props.close()
+
   render: ->
-    (ModalDialog {title: tr '~CONFIRM_DIALOG.TITLE', close: @props.close, zIndex: 100},
+    (ModalDialog {title: @props.title or tr '~CONFIRM_DIALOG.TITLE', close: @props.close, zIndex: 100},
       (div {className: 'confirm-dialog'},
         (div {className: 'confirm-dialog-message'}, @props.message)
         (div {className: 'buttons'},
-          (button {onClick: @confirm}, tr '~CONFIRM_DIALOG.YES')
-          (button {onClick: @props.close}, tr '~CONFIRM_DIALOG.NO')
+          (button {onClick: @confirm}, @props.yesTitle or tr '~CONFIRM_DIALOG.YES')
+          (button {onClick: @reject}, @props.noTitle or tr '~CONFIRM_DIALOG.NO')
         )
       )
     )

--- a/src/code/views/confirm-dialog-view.coffee
+++ b/src/code/views/confirm-dialog-view.coffee
@@ -10,16 +10,16 @@ module.exports = React.createClass
 
   confirm: ->
     @props.callback?()
-    @props.close()
+    @props.close?()
 
   reject: ->
     @props.rejectCallback?()
-    @props.close()
+    @props.close?()
 
   render: ->
-    (ModalDialog {title: @props.title or tr '~CONFIRM_DIALOG.TITLE', close: @props.close, zIndex: 500},
+    (ModalDialog {title: (@props.title or tr '~CONFIRM_DIALOG.TITLE'), close: @reject, zIndex: 500},
       (div {className: 'confirm-dialog'},
-        (div {className: 'confirm-dialog-message'}, @props.message)
+        (div {className: 'confirm-dialog-message', dangerouslySetInnerHTML: {__html: @props.message}})
         (div {className: 'buttons'},
           (button {onClick: @confirm}, @props.yesTitle or tr '~CONFIRM_DIALOG.YES')
           (button {onClick: @reject}, @props.noTitle or tr '~CONFIRM_DIALOG.NO')

--- a/src/code/views/confirm-dialog-view.coffee
+++ b/src/code/views/confirm-dialog-view.coffee
@@ -17,7 +17,7 @@ module.exports = React.createClass
     @props.close()
 
   render: ->
-    (ModalDialog {title: @props.title or tr '~CONFIRM_DIALOG.TITLE', close: @props.close, zIndex: 100},
+    (ModalDialog {title: @props.title or tr '~CONFIRM_DIALOG.TITLE', close: @props.close, zIndex: 500},
       (div {className: 'confirm-dialog'},
         (div {className: 'confirm-dialog-message'}, @props.message)
         (div {className: 'buttons'},

--- a/src/code/views/modal-dialog-view.coffee
+++ b/src/code/views/modal-dialog-view.coffee
@@ -9,7 +9,7 @@ module.exports = React.createClass
     @props.close?()
 
   render: ->
-    (Modal {close: @props.close, zIndex: @props.zIndex},
+    (Modal {close: @close, zIndex: @props.zIndex},
       (div {className: 'modal-dialog'},
         (div {className: 'modal-dialog-wrapper'},
           (div {className: 'modal-dialog-title'},

--- a/src/code/views/provider-tabbed-dialog-view.coffee
+++ b/src/code/views/provider-tabbed-dialog-view.coffee
@@ -27,7 +27,8 @@ module.exports = React.createClass
             dialog: @props.dialog
             close: @props.close
             provider: provider
-          tabs.push TabbedPanel.Tab {key: i, label: (tr provider.displayName), component: component}
+          onSelected = if provider.onProviderTabSelected then provider.onProviderTabSelected.bind(provider) else null
+          tabs.push TabbedPanel.Tab {key: i, label: (tr provider.displayName), component: component, capability: capability, onSelected: onSelected}
           if provider.name is @props.client.state.metadata?.provider?.name
             selectedTabIndex = tabs.length - 1
 

--- a/src/code/views/tabbed-panel-view.coffee
+++ b/src/code/views/tabbed-panel-view.coffee
@@ -2,7 +2,7 @@
 
 class TabInfo
   constructor: (settings={}) ->
-    {@label, @component} = settings
+    {@label, @component, @capability, @onSelected} = settings
 
 Tab = React.createFactory React.createClass
 
@@ -23,10 +23,14 @@ module.exports = React.createClass
   getInitialState: ->
     selectedTabIndex: @props.selectedTabIndex or 0
 
+  componentDidMount: ->
+    @props.tabs[@state.selectedTabIndex].onSelected?(@props.tabs[@state.selectedTabIndex].capability)
+
   statics:
     Tab: (settings) -> new TabInfo settings
 
   selectedTab: (index) ->
+    @props.tabs[index].onSelected?(@props.tabs[index].capability)
     @setState selectedTabIndex: index
 
   renderTab: (tab, index) ->


### PR DESCRIPTION
Note: This PR depends on [PR#36](https://github.com/concord-consortium/cloud-file-manager/pull/36). Once that is merged, this PR can be rebased accordingly.

Add deprecation warnings for Concord Cloud when opening a document
- DocumentStoreProvider supports 'deprecationPhase' option
- Providers have an opportunity to put up a dialog when files are opened
- DocumentStoreProvider puts up deprecation alert on file open based on deprecationPhase
- Saving (including auto-save) is enabled in phase 1; all saving is disabled in phase 2
- Partially addresses [#129634575] and [#129634587]
- The first commit does not address the save dialog changes described in those stories
- Enhance ConfirmDialogView component to support configurable title, button labels, and a reject callback.

To test this one must also change the CFM configuration in CODAP a bit, namely by adding a `deprecationPhase` option to the documentStore configuration and enabling the LaraProvider by adding 
```            
{
    "name": "lara"
}
```

to the provider configuration section.