### PR TITLE
Save secondary file

### DIFF
--- a/src/assets/examples/example-app/index.html
+++ b/src/assets/examples/example-app/index.html
@@ -34,6 +34,10 @@
         cfmClient && cfmClient.saveFileAsDialog(getContent());
       }
 
+      function saveSecondaryFileAs() {
+        cfmClient && cfmClient.saveSecondaryFileAsDialog(getContent(), "csv");
+      }
+
       function getContent() {
         return document.getElementById("text").value;
       }
@@ -81,6 +85,7 @@
       <button onclick="openFile()">Open</button>
       <button onclick="saveFile()">Save</button>
       <button onclick="saveFileAs()">Save As</button>
+      <button onclick="saveSecondaryFileAs()">Export Separate File</button>
     </div>
     <div>
       Import Local File: <input type="file" onchange="importLocalFile(event)">

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -508,6 +508,26 @@ class CloudFileManagerClient
     else
       callback? 'No initial opened version was found for the currently active file'
 
+  saveSecondaryFileAsDialog: (stringContent, extension, callback) ->
+    @_ui.saveSecondaryFileAsDialog (metadata) =>
+      if extension
+        # replace default extension
+        metadata.filename = CloudMetadata.newExtension metadata.filename, extension
+      @saveSecondaryFile stringContent, metadata, callback
+
+  # Saves a file to backend, but does not update current metadata.
+  # Used e.g. when exporting .csv files from CODAP
+  saveSecondaryFile: (stringContent, metadata, callback = null) ->
+    if metadata?.provider?.can 'save'
+      @_setState
+        saving: metadata
+      metadata.provider.save stringContent, metadata, (err, statusCode) =>
+        if err
+          return @alert(err)
+        @_setState
+          saving: null
+        callback? currentContent, metadata
+
   dirty: (isDirty = true)->
     @_setState
       dirty: isDirty

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -508,11 +508,14 @@ class CloudFileManagerClient
     else
       callback? 'No initial opened version was found for the currently active file'
 
-  saveSecondaryFileAsDialog: (stringContent, extension, callback) ->
+  saveSecondaryFileAsDialog: (stringContent, extension, mimeType, callback) ->
     @_ui.saveSecondaryFileAsDialog (metadata) =>
+      # replace defaults
       if extension
-        # replace default extension
         metadata.filename = CloudMetadata.newExtension metadata.filename, extension
+      if mimeType
+        metadata.mimeType = mimeType
+
       @saveSecondaryFile stringContent, metadata, callback
 
   # Saves a file to backend, but does not update current metadata.

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -47,6 +47,7 @@ class GoogleDriveProvider extends ProviderInterface
         rename: true
         close: true
         setFolder: true
+        saveUnwrapped: true
 
     @authToken = null
     @user = null
@@ -255,7 +256,7 @@ class GoogleDriveProvider extends ProviderInterface
 
     body = [
       "\r\n--#{boundary}\r\nContent-Type: application/json\r\n\r\n#{header}",
-      "\r\n--#{boundary}\r\nContent-Type: #{@mimeType}\r\n\r\n#{content.getContentAsJSON()}",
+      "\r\n--#{boundary}\r\nContent-Type: #{@mimeType}\r\n\r\n#{content.getContentAsJSON?() or content}",
       "\r\n--#{boundary}--"
     ].join ''
 

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -244,9 +244,10 @@ class GoogleDriveProvider extends ProviderInterface
 
   _saveFile: (content, metadata, callback) ->
     boundary = '-------314159265358979323846'
+    mimeType = metadata.mimeType or @mimeType
     header = JSON.stringify
       title: metadata.filename
-      mimeType: @mimeType
+      mimeType: mimeType
       parents: [{id: if metadata.parent?.providerData?.id? then metadata.parent.providerData.id else 'root'}]
 
     [method, path] = if metadata.providerData?.id
@@ -256,7 +257,7 @@ class GoogleDriveProvider extends ProviderInterface
 
     body = [
       "\r\n--#{boundary}\r\nContent-Type: application/json\r\n\r\n#{header}",
-      "\r\n--#{boundary}\r\nContent-Type: #{@mimeType}\r\n\r\n#{content.getContentAsJSON?() or content}",
+      "\r\n--#{boundary}\r\nContent-Type: #{mimeType}\r\n\r\n#{content.getContentAsJSON?() or content}",
       "\r\n--#{boundary}--"
     ].join ''
 

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -255,9 +255,14 @@ class GoogleDriveProvider extends ProviderInterface
     else
       ['POST', '/upload/drive/v2/files']
 
+    transferEncoding = ""
+    if mimeType.indexOf("image/") is 0
+      # assume we're transfering any images as base64
+      transferEncoding = "\r\nContent-Transfer-Encoding: base64"
+
     body = [
       "\r\n--#{boundary}\r\nContent-Type: application/json\r\n\r\n#{header}",
-      "\r\n--#{boundary}\r\nContent-Type: #{mimeType}\r\n\r\n#{content.getContentAsJSON?() or content}",
+      "\r\n--#{boundary}\r\nContent-Type: #{mimeType}#{transferEncoding}\r\n\r\n#{content.getContentAsJSON?() or content}",
       "\r\n--#{boundary}--"
     ].join ''
 

--- a/src/code/providers/localstorage-provider.coffee
+++ b/src/code/providers/localstorage-provider.coffee
@@ -18,6 +18,7 @@ class LocalStorageProvider extends ProviderInterface
         remove: true
         rename: true
         close: false
+        saveUnwrapped: true
 
   @Name: 'localStorage'
   @Available: ->
@@ -32,7 +33,7 @@ class LocalStorageProvider extends ProviderInterface
   save: (content, metadata, callback) ->
     try
       fileKey = @_getKey(metadata.filename)
-      window.localStorage.setItem fileKey, content.getContentAsJSON()
+      window.localStorage.setItem fileKey, (content.getContentAsJSON?() or content)
       callback? null
     catch e
       callback "Unable to save: #{e.message}"

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -8,7 +8,7 @@ class CloudFile
 
 class CloudMetadata
   constructor: (options) ->
-    {@name, @type, @description, @content, @url, @provider = null, @parent = null, @providerData={}, @overwritable, @sharedContentId, @sharedContentSecretKey} = options
+    {@name, @type, @description, @content, @url, @provider = null, @parent = null, @providerData={}, @overwritable, @sharedContentId, @sharedContentSecretKey, @mimeType} = options
     @_updateFilename()
 
   @Folder: 'folder'

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -31,8 +31,8 @@ class CloudMetadata
       name
 
   @newExtension: (name, extension) ->
-    if ~name.indexOf(".")
-      name = name.split(".")[0]
+    # drop last extension, if there is one
+    name = name.substr(0, name.lastIndexOf('.')) or name
     name + "." + extension
 
   path: ->

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -30,6 +30,11 @@ class CloudMetadata
     else
       name
 
+  @newExtension: (name, extension) ->
+    if ~name.indexOf(".")
+      name = name.split(".")[0]
+    name + "." + extension
+
   path: ->
     _path = []
     parent = @parent

--- a/src/code/ui.coffee
+++ b/src/code/ui.coffee
@@ -49,6 +49,7 @@ class CloudFileManagerUIMenu
       revertToSharedDialog: tr "~MENU.REVERT_TO_SHARED_VIEW"
       save: tr "~MENU.SAVE"
       saveFileAsDialog: tr "~MENU.SAVE_AS"
+      saveSecondaryFileAsDialog: tr "~MENU.EXPORT_AS"
       createCopy: tr "~MENU.CREATE_COPY"
       shareGetLink: tr "~MENU.SHARE_GET_LINK"
       shareUpdate: tr "~MENU.SHARE_UPDATE"
@@ -138,6 +139,9 @@ class CloudFileManagerUI
 
   saveFileAsDialog: (callback) ->
     @_showProviderDialog 'saveFileAs', (tr '~DIALOG.SAVE_AS'), callback
+
+  saveSecondaryFileAsDialog: (callback) ->
+    @_showProviderDialog 'saveSecondaryFileAs', (tr '~DIALOG.EXPORT_AS'), callback
 
   openFileDialog: (callback) ->
     @_showProviderDialog 'openFile', (tr '~DIALOG.OPEN'), callback

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -7,6 +7,7 @@ module.exports =
   "~MENU.IMPORT_DATA": "Import data..."
   "~MENU.SAVE": "Save"
   "~MENU.SAVE_AS": "Save As ..."
+  "~MENU.EXPORT_AS": "Export File As ..."
   "~MENU.CREATE_COPY": "Create a copy"
   "~MENU.SHARE": "Share..."
   "~MENU.SHARE_GET_LINK": "Get link to shared view"
@@ -19,6 +20,7 @@ module.exports =
 
   "~DIALOG.SAVE": "Save"
   "~DIALOG.SAVE_AS": "Save As ..."
+  "~DIALOG.EXPORT_AS": "Export File As ..."
   "~DIALOG.CREATE_COPY": "Create A Copy ..."
   "~DIALOG.OPEN": "Open"
   "~DIALOG.DOWNLOAD": "Download"

--- a/src/code/views/file-dialog-tab-view.coffee
+++ b/src/code/views/file-dialog-tab-view.coffee
@@ -92,7 +92,7 @@ FileDialogTab = React.createClass
     @setState list: list
 
   getStateForFolder: (folder) ->
-    metadata = if @isOpen() then @state?.metadata or null else @props.client.state.metadata
+    metadata = if @isOpen() then @state?.metadata or null else _.cloneDeep @props.client.state.metadata
     metadata?.parent = folder
 
     if @props.client.state.metadata and (@props.provider isnt @props.client.state.metadata.provider)

--- a/src/code/views/provider-tabbed-dialog-view.coffee
+++ b/src/code/views/provider-tabbed-dialog-view.coffee
@@ -13,6 +13,7 @@ module.exports = React.createClass
     [capability, TabComponent] = switch @props.dialog.action
       when 'openFile' then ['list', FileDialogTab]
       when 'saveFile', 'saveFileAs' then ['save', FileDialogTab]
+      when 'saveSecondaryFileAs' then ['saveUnwrapped', FileDialogTab]
       when 'createCopy' then ['save', FileDialogTab]
       when 'selectProvider' then [null, SelectProviderDialogTab]
 


### PR DESCRIPTION
Allows CFM to save a file to a provider, without affecting the current metadata. Used for exporting .csv files in CODAP.

https://www.pivotaltracker.com/story/show/127512941