### PR TITLE
Fix bug in handling of null file names

### DIFF
--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -173,6 +173,7 @@ class ProviderInterface
     defaultComponent
 
   matchesExtension: (name) ->
+    return false if not name
     if CloudMetadata.ReadableExtensions? and CloudMetadata.ReadableExtensions.length > 0
       for extension in CloudMetadata.ReadableExtensions
         return true if name.substr(-extension.length) is extension


### PR DESCRIPTION
Fix handling of null file names in ProviderInterface.matchesExtension()
Null file names can be created by the Document Store

In the V2 doc store API, file names can be empty or null, as they aren't really used for anything any more. Even though we haven't deployed the V2 API to production, anyone that has been testing the V2 API are liable to have documents with null or empty names in their Concord Cloud accounts. Preexisting code for matching file names to extensions wasn't handling null file names. We add the necessary test to the matchesExtension() function, but there may be other places that requires similar treatment.

Note: for this to take effect in CODAP, the corresponding CODAP [PR#90](https://github.com/concord-consortium/codap/pull/90) must be merged.