### PR TITLE
Fix Save As bug detected during Concord Cloud deprecation testing

### DIFF
--- a/src/code/views/file-dialog-tab-view.coffee
+++ b/src/code/views/file-dialog-tab-view.coffee
@@ -117,7 +117,10 @@ FileDialogTab = React.createClass
     confirmed = (metadata) =>
       # ensure the metadata provider is the currently-showing tab
       @state.metadata = metadata
-      @state.metadata.provider = @props.provider
+      if @state.metadata.provider isnt @props.provider
+        @state.metadata.provider = @props.provider
+        # if switching provider, then clear providerData
+        @state.metadata.providerData = {}
       @props.dialog.callback? @state.metadata
       @props.close()
 


### PR DESCRIPTION
When switching providers (e.g. saving a file previously saved to Concord Cloud to Google Drive) the provider-specific data in the metadata must be cleared or it can confuse the new provider.