### PR TITLE
Added missing check for error in list for Google Drive provider

### DIFF
--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -132,7 +132,7 @@ class GoogleDriveProvider extends ProviderInterface
       request = gapi.client.drive.files.list
         q: query = "trashed = false and (#{mimeTypesQuery} or mimeType = 'application/vnd.google-apps.folder') and '#{if metadata then metadata.providerData.id else 'root'}' in parents"
       request.execute (result) =>
-        return callback('Unable to list files') if not result
+        return callback(@_apiError(result, 'Unable to list files')) if not result or result.error
         list = []
         for item in result?.items
           type = if item.mimeType is 'application/vnd.google-apps.folder' then CloudMetadata.Folder else CloudMetadata.File


### PR DESCRIPTION
This was the only place we were not checking for the error message in the returned results.  This should surface the errors thrown for these two stories:

- https://www.pivotaltracker.com/n/projects/1055240/stories/131230747
- https://www.pivotaltracker.com/n/projects/1055240/stories/131230545