### PR TITLE
Fixes setting parent folder on newly-saved docs

### DIFF
--- a/src/code/views/file-dialog-tab-view.coffee
+++ b/src/code/views/file-dialog-tab-view.coffee
@@ -108,7 +108,7 @@ FileDialogTab = React.createClass
     metadata = if @isOpen() then @state?.metadata or null else @getSaveMetadata()
     metadata?.parent = folder
 
-    if @props.client.state.metadata and (@props.provider isnt @props.client.state.metadata.provider)
+    if @props.client.state.metadata?.provider and (@props.provider isnt @props.client.state.metadata.provider)
       folder = null
 
     folder: folder
@@ -117,8 +117,7 @@ FileDialogTab = React.createClass
 
   fileSelected: (metadata) ->
     if metadata?.type is CloudMetadata.Folder
-      @setState
-        folder: metadata
+      @setState @getStateForFolder metadata
     else if metadata?.type is CloudMetadata.File
       @setState
         filename: metadata.name


### PR DESCRIPTION
Previously, 707b1cf0 fixed https://www.pivotaltracker.com/n/projects/1055240/stories/120377399,
allowing us to select a parent folder even if we didn't type a name into the Save As dialog.

Then I committed c650f1e6, to fix https://www.pivotaltracker.com/n/projects/1055240/stories/127762907,
making sure we didn't keep a record of the parent folder when switching to different providers.

However, that fix caused a regression which broke the first one. This fix corrects that.

[#130682993]