### PR TITLE
Update Concord Cloud deprecation phase dates; add phase 3 dialog

### DIFF
--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -183,6 +183,7 @@ class DocumentStoreProvider extends ProviderInterface
     messages = [
       tr '~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_1'
       tr '~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_2'
+      tr '~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_3'
     ]
     if @options.deprecationPhase > 0 and @options.deprecationPhase <= messages.length
       messages[@options.deprecationPhase - 1]
@@ -384,6 +385,7 @@ class DocumentStoreProvider extends ProviderInterface
       message: @deprecationMessage()
       yesTitle: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_SAVE_ELSEWHERE'
       noTitle: tr '~CONCORD_CLOUD_DEPRECATION.CONFIRM_DO_IT_LATER'
+      hideNoButton: deprecationPhase >= 3
       callback: =>
         @disableForNextSave = true
         @client.saveFileAsDialog()

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -109,8 +109,8 @@ module.exports =
           <strong>The Concord Cloud is shutting down soon!</strong>
         </p>
         <ul style="margin: 10px 20px;">
-          <li>Nov. 1: Saving to the Concord Cloud will be disabled.</li>
-          <li>Jan. 1: Opening from the Concord Cloud will be disabled.</li>
+          <li>Nov 15, 2016: Saving to the Concord Cloud will be disabled.</li>
+          <li>Jan 1, 2017: Opening from the Concord Cloud will be disabled.</li>
         </ul>
         <p style="margin: 10px 0;">
           Please save your documents to another location as soon as possible.
@@ -123,11 +123,25 @@ module.exports =
           <strong>The Concord Cloud is shutting down soon!</strong>
         </p>
         <ul style="margin: 10px 20px;">
-          <li>Nov. 1: Saving to the Concord Cloud was disabled.</li>
-          <li>Jan. 1: Opening from the Concord Cloud will be disabled.</li>
+          <li>Nov 15, 2016: Saving to the Concord Cloud was disabled.</li>
+          <li>Jan 1, 2017: Opening from the Concord Cloud will be disabled.</li>
         </ul>
         <p style="margin: 10px 0;">
           Please save your documents to another location as soon as possible.
+        </p>
+      </div>
+    """
+  "~CONCORD_CLOUD_DEPRECATION.SAVE_PHASE_3": """
+      <div style="text-align: left">
+        <p style="margin: 10px 0;">
+          <strong>The Concord Cloud has been shut down!</strong>
+        </p>
+        <ul style="margin: 10px 20px;">
+          <li>Nov 15, 2016: Saving to the Concord Cloud was disabled.</li>
+          <li>Jan 1, 2017: Opening from the Concord Cloud was disabled.</li>
+        </ul>
+        <p style="margin: 10px 0;">
+          Please save your documents to another location.
         </p>
       </div>
     """

--- a/src/code/views/confirm-dialog-view.coffee
+++ b/src/code/views/confirm-dialog-view.coffee
@@ -22,7 +22,7 @@ module.exports = React.createClass
         (div {className: 'confirm-dialog-message', dangerouslySetInnerHTML: {__html: @props.message}})
         (div {className: 'buttons'},
           (button {onClick: @confirm}, @props.yesTitle or tr '~CONFIRM_DIALOG.YES')
-          (button {onClick: @reject}, @props.noTitle or tr '~CONFIRM_DIALOG.NO')
+          ((button {onClick: @reject}, @props.noTitle or tr '~CONFIRM_DIALOG.NO') if not @props.hideNoButton)
         )
       )
     )


### PR DESCRIPTION
- Update dates in deprecation dialogs [#131815401]
- Add missing phase 3 dialog (can get there with documents opened from URL parameter)

Note: This is easier to test with CODAP PR [PR#94](https://github.com/concord-consortium/codap/pull/94) which adds support for a query param override.