### PR TITLE
Another fix for subfolders and switching providers

### DIFF
--- a/src/code/views/file-dialog-tab-view.coffee
+++ b/src/code/views/file-dialog-tab-view.coffee
@@ -56,7 +56,7 @@ FileList = React.createFactory React.createClass
 
   render: ->
     list = []
-    isSubFolder = @props.folder isnt null
+    isSubFolder = @props.folder?
     if isSubFolder
       list.push (div {key: 'parent', className: 'selectable', onClick: @parentSelected}, (React.DOM.i {className: 'icon-paletteArrow-collapse'}), @props.folder.name)
     for metadata, i in @props.list
@@ -75,7 +75,7 @@ FileDialogTab = React.createClass
   mixins: [AuthorizeMixin]
 
   getInitialState: ->
-    initialState = @getStateForFolder @props.client.state.metadata?.parent or null
+    initialState = @getStateForFolder(@props.client.state.metadata?.parent, true) or null
     initialState.filename = initialState.metadata?.name or ''
     initialState
 
@@ -105,12 +105,13 @@ FileDialogTab = React.createClass
         saveMetadata.providerData = null
     saveMetadata
 
-  getStateForFolder: (folder) ->
+  getStateForFolder: (folder, initialFolder) ->
     metadata = if @isOpen() then @state?.metadata or null else @getSaveMetadata()
-    metadata?.parent = folder
 
-    if @props.client.state.metadata?.provider and (@props.provider isnt @props.client.state.metadata.provider)
+    if initialFolder and (@props.client.state.metadata?.provider isnt @props.provider)
       folder = null
+    else
+      metadata?.parent = folder
 
     folder: folder
     metadata: metadata


### PR DESCRIPTION
This fixes the following three scenarios:

1. Correctly save a file to a subfolder in Drive
2. If you open a read-only file, save it to a subfolder in Drive
3. If you open a file from a subfolder in Drive, you can then open from
another provider without it showing that folder name

This area, as @kswenson has mentioned, has had a lot of churn. The two
main issues are (1) confusion over setting metadata parent and setting
folder state, and (2) all the provider views are initialized at the
same time, not when the user switches between them. This makes sense,
but makes it a little harder to reason correctly about.