### PR TITLE
Support saving secondary files (e.g. CSV) to the Local File provider

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -487,10 +487,14 @@ class CloudFileManagerClient
       @_ui.downloadDialog @state.metadata?.name, envelopedContent, callback
 
   getDownloadUrl: (content, includeShareInfo) ->
-    contentToSave = content
+    if typeof content is "string"
+      contentToSave = content
 
-    if not includeShareInfo
-      # clone the document so we can delete the share info if needed and not effect the original
+    else if includeShareInfo
+      contentToSave = JSON.stringify(content.getContent())
+
+    else # not includeShareInfo
+      # clone the document so we can delete the share info and not affect the original
       json = content.clone().getContent()
       delete json.sharedDocumentId
       delete json.shareEditKey

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -487,19 +487,22 @@ class CloudFileManagerClient
       @_ui.downloadDialog @state.metadata?.name, envelopedContent, callback
 
   getDownloadUrl: (content, includeShareInfo) ->
-    # clone the document so we can delete the share info if needed and not effect the original
-    json = content.clone().getContent()
+    contentToSave = content
+
     if not includeShareInfo
+      # clone the document so we can delete the share info if needed and not effect the original
+      json = content.clone().getContent()
       delete json.sharedDocumentId
       delete json.shareEditKey
       delete json.isUnshared
       delete json.accessKeys
       # CODAP moves the keys into its own namespace
       delete json.metadata.shared if json.metadata?.shared?
+      contentToSave = JSON.stringify(json)
 
     wURL = window.URL or window.webkitURL
     downloadUrl = if wURL
-      blob = new Blob([JSON.stringify(json)], {type: 'text/plain'})
+      blob = new Blob([contentToSave], {type: 'text/plain'})
       wURL.createObjectURL blob
     else
       null
@@ -541,7 +544,8 @@ class CloudFileManagerClient
       callback? 'No initial opened version was found for the currently active file'
 
   saveSecondaryFileAsDialog: (stringContent, extension, mimeType, callback) ->
-    @_ui.saveSecondaryFileAsDialog (metadata) =>
+    data = { content: stringContent, extension, mimeType }
+    @_ui.saveSecondaryFileAsDialog data, (metadata) =>
       # replace defaults
       if extension
         metadata.filename = CloudMetadata.newExtension metadata.filename, extension

--- a/src/code/providers/document-store-share-provider.coffee
+++ b/src/code/providers/document-store-share-provider.coffee
@@ -84,7 +84,7 @@ class DocumentStoreShareProvider
         xhrFields:
           withCredentials: true
         success: (data) ->
-          # on successful share/save, capture the sharedDocumentId and accesKeys
+          # on successful share/save, capture the sharedDocumentId and accessKeys
           masterContent.addMetadata
             sharedDocumentId: data.id
             accessKeys: { readOnly: data.readAccessKey, readWrite: data.readWriteAccessKey }

--- a/src/code/providers/local-file-provider.coffee
+++ b/src/code/providers/local-file-provider.coffee
@@ -20,22 +20,23 @@ class LocalFileProvider extends ProviderInterface
         rename: false
         close: false
         autoSave: false
+        saveUnwrapped: true
 
   @Name: 'localFile'
 
   filterTabComponent: (capability, defaultComponent) ->
     if capability is 'list'
       LocalFileListTab
-    else if capability is 'save'
+    else if (capability is 'save') or (capability is 'saveUnwrapped')
       LocalFileSaveTab
     else
       defaultComponent
 
   list: (metadata, callback) ->
-    # no really implemented - we flag it as implemented so we show in the list dialog
+    # not really implemented - we flag it as implemented so we show in the list dialog
 
   save: (content, metadata, callback) ->
-    # no really implemented - we flag it as implemented so we can add the download button to the save dialog
+    # not really implemented - we flag it as implemented so we can add the download button to the save dialog
     callback? null
 
   load: (metadata, callback) ->

--- a/src/code/ui.coffee
+++ b/src/code/ui.coffee
@@ -140,8 +140,8 @@ class CloudFileManagerUI
   saveFileAsDialog: (callback) ->
     @_showProviderDialog 'saveFileAs', (tr '~DIALOG.SAVE_AS'), callback
 
-  saveSecondaryFileAsDialog: (callback) ->
-    @_showProviderDialog 'saveSecondaryFileAs', (tr '~DIALOG.EXPORT_AS'), callback
+  saveSecondaryFileAsDialog: (data, callback) ->
+    @_showProviderDialog 'saveSecondaryFileAs', (tr '~DIALOG.EXPORT_AS'), callback, data
 
   openFileDialog: (callback) ->
     @_showProviderDialog 'openFile', (tr '~DIALOG.OPEN'), callback
@@ -184,11 +184,12 @@ class CloudFileManagerUI
   confirmDialog: (params) ->
     @listenerCallback new CloudFileManagerUIEvent 'showConfirmDialog', params
 
-  _showProviderDialog: (action, title, callback) ->
+  _showProviderDialog: (action, title, callback, data) ->
     @listenerCallback new CloudFileManagerUIEvent 'showProviderDialog',
       action: action
       title: title
       callback: callback
+      data: data
 
 module.exports =
   CloudFileManagerUIEvent: CloudFileManagerUIEvent

--- a/src/code/views/local-file-tab-save-view.coffee
+++ b/src/code/views/local-file-tab-save-view.coffee
@@ -8,41 +8,56 @@ module.exports = React.createClass
   displayName: 'LocalFileSaveTab'
 
   getInitialState: ->
-    filename = CloudMetadata.withExtension(@props.client.state.metadata?.name or (tr "~MENUBAR.UNTITLED_DOCUMENT"), 'json')
+    # If the dialog has the content to save, which occurs when saving secondary content
+    # like CSV files, then use that instead of the document content and make sure that
+    # it doesn't get modified by (for instance) trying to remove sharing metadata. To
+    # do so, we specify that we want to include the share info, which tells the client
+    # to leave the content alone.
+    hasPropsContent = @props.dialog.data?.content?
+    filename = @props.client.state.metadata?.name or (tr "~MENUBAR.UNTITLED_DOCUMENT")
+    extension = if hasPropsContent and @props.dialog.data.extension \
+                  then @props.dialog.data.extension \
+                  else 'json'
     state =
       filename: filename
-      trimmedFilename: @trim filename
+      downloadFilename: @getDownloadFilename hasPropsContent, filename, extension
+      extension: extension
       shared: @props.client.isShared()
-      includeShareInfo: false
-      gotContent: false
-      content: null
+      hasPropsContent: hasPropsContent
+      includeShareInfo: hasPropsContent
+      gotContent: hasPropsContent
+      content: @props.dialog.data?.content
 
   componentDidMount: ->
-    @props.client._event 'getContent', { shared: @props.client._sharedMetadata() }, (content) =>
-      envelopedContent = cloudContentFactory.createEnvelopedCloudContent content
-      @props.client.state?.currentContent?.copyMetadataTo envelopedContent
-      @setState
-        gotContent: true
-        content: envelopedContent
+    if not @state.hasPropsContent
+      @props.client._event 'getContent', { shared: @props.client._sharedMetadata() }, (content) =>
+        envelopedContent = cloudContentFactory.createEnvelopedCloudContent content
+        @props.client.state?.currentContent?.copyMetadataTo envelopedContent
+        @setState
+          gotContent: true
+          content: envelopedContent
 
   filenameChanged: ->
     filename = @refs.filename.value
     @setState
       filename: filename
-      trimmedFilename: @trim filename
+      downloadFilename: @getDownloadFilename @state.hasPropsContent, filename, @state.extension
 
   includeShareInfoChanged: ->
     @setState includeShareInfo: @refs.includeShareInfo.checked
 
-  trim: (s) ->
-    s.replace /^\s+|\s+$/, ''
+  getDownloadFilename: (hasPropsContent, filename, extension) ->
+    newName = filename.replace /^\s+|\s+$/, ''
+    if hasPropsContent \
+      then CloudMetadata.newExtension(newName, extension) \
+      else CloudMetadata.withExtension(newName, extension)
 
   confirm: (e, simulateClick) ->
     if not @confirmDisabled()
       @refs.download.href = @props.client.getDownloadUrl(@state.content, @state.includeShareInfo)
       @refs.download.click() if simulateClick
       metadata = new CloudMetadata
-        name: @state.trimmedFilename.split('.')[0]
+        name: @state.downloadFilename.split('.')[0]
         type: CloudMetadata.File
         parent: null
         provider: @props.provider
@@ -61,7 +76,7 @@ module.exports = React.createClass
       @confirm(null, true)
 
   confirmDisabled: ->
-    (@state.trimmedFilename.length is 0) or not @state.gotContent
+    (@state.downloadFilename.length is 0) or not @state.gotContent
 
   render: ->
     confirmDisabled = @confirmDisabled()
@@ -69,7 +84,7 @@ module.exports = React.createClass
     (div {className: 'dialogTab localFileSave'},
       (input {type: 'text', ref: 'filename', value: @state.filename, placeholder: (tr "~FILE_DIALOG.FILENAME"), onChange: @filenameChanged, onKeyDown: @watchForEnter}),
       (div {className: 'saveArea'},
-        if @state.shared
+        if @state.shared and not @state.hasPropsContent
           (div {className: 'shareCheckbox'},
             (input {type: 'checkbox', ref: 'includeShareInfo', value: @state.includeShareInfo, onChange: @includeShareInfoChanged})
             (tr '~DOWNLOAD_DIALOG.INCLUDE_SHARE_INFO')
@@ -77,7 +92,7 @@ module.exports = React.createClass
       )
       div({className: 'note'}, tr('~FILE_DIALOG.DOWNLOAD_NOTE', {download: tr('~FILE_DIALOG.DOWNLOAD')}))
       (div {className: 'buttons'},
-        (a {href: '#', ref: 'download', className: (if confirmDisabled then 'disabled' else ''), download: @state.trimmedFilename, onClick: @confirm}, tr '~FILE_DIALOG.DOWNLOAD')
+        (a {href: '#', ref: 'download', className: (if confirmDisabled then 'disabled' else ''), download: @state.downloadFilename, onClick: @confirm}, tr '~FILE_DIALOG.DOWNLOAD')
         (button {onClick: @cancel}, (tr "~FILE_DIALOG.CANCEL"))
       )
     )


### PR DESCRIPTION
- allow Local File provider to be selected in export dialog
- support saving/downloading secondary content

This PR ties together Sam's earlier work to [support CSV export](https://github.com/concord-consortium/codap/pull/91) and Doug's recent work to support [local file saving/downloading](https://github.com/concord-consortium/cloud-file-manager/pull/61) so that it is possible to download/save exported CSVs locally. @dougmartin I embarked on this thinking it might be a quick fix before merging your CFM changes into Sam's outstanding PR. It turned out to be a bit more involved.