### PR TITLE
Support legacy sharing with 'doc' and 'owner' query parameters

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -715,8 +715,8 @@ class CloudFileManagerClient
       document.title = "#{if name?.length > 0 then name else (tr "~MENUBAR.UNTITLED_DOCUMENT")}#{@appOptions.ui.windowTitleSeparator}#{@appOptions.ui.windowTitleSuffix}"
 
   _getHashParams: (metadata) ->
-    if metadata?.provider?.canOpenSaved()
-      "#file=#{metadata.provider.urlDisplayName or metadata.provider.name}:#{encodeURIComponent metadata.provider.getOpenSavedParams metadata}"
+    if metadata?.provider?.canOpenSaved() and (openSavedParams = metadata?.provider?.getOpenSavedParams metadata)?
+      "#file=#{metadata.provider.urlDisplayName or metadata.provider.name}:#{encodeURIComponent openSavedParams}"
     else if metadata?.provider instanceof URLProvider and
         window.location.hash.indexOf("#file=http") is 0
       window.location.hash    # leave it alone

--- a/src/code/views/file-dialog-tab-view.coffee
+++ b/src/code/views/file-dialog-tab-view.coffee
@@ -103,6 +103,7 @@ FileDialogTab = React.createClass
       else
         saveMetadata.provider = null
         saveMetadata.providerData = null
+        saveMetadata.forceSaveDialog = false
     saveMetadata
 
   getStateForFolder: (folder, initialFolder) ->


### PR DESCRIPTION
- save triggers save as dialog for saving unshared copy
- fixed bug that could prevent saving to another provider after saving to the local file provider

This was the last bit of document save/restore code still being handled by CODAP. Moving it to the CFM enables a much more complete cleanup of the document save/restore code in CODAP.