### PR TITLE
Set shared docname from master doc [#134644127]

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -444,6 +444,7 @@ class CloudFileManagerClient
         sharedContent = cloudContentFactory.createEnvelopedCloudContent stringContent
         sharedContent.addMetadata sharingMetadata
         currentContent = @_createOrUpdateCurrentContent stringContent, @state.metadata
+        sharedContent.set('docName', currentContent.get('docName'))
         if shared
           currentContent.remove 'isUnshared'
         else


### PR DESCRIPTION
Before this change the shared document would always be untitled.  Now the shared document is named the same as the master document when the shared document is created or updated.