### PR TITLE
Declare explicit dependency on pako library in LaraProvider

### DIFF
--- a/src/code/providers/lara-provider.coffee
+++ b/src/code/providers/lara-provider.coffee
@@ -5,6 +5,7 @@ DocumentStoreUrl = require './document-store-url'
 PatchableContent = require './patchable-content'
 getQueryParam = require '../utils/get-query-param'
 base64 = (require 'js-base64').Base64
+pako = require 'pako'
 
 # This provider supports the lara:... protocol used for documents launched
 # from LARA. It looks up the document ID and access keys from the LARA


### PR DESCRIPTION
Declare explicit dependency on pako library in LaraProvider [#134879527]
- previously, code was implicitly relying on presence of pako global, which was recently removed
