### PR TITLE
Fixed filename input not closing when user clicks in document [#127301439]

### DIFF
--- a/src/code/views/menu-bar-view.coffee
+++ b/src/code/views/menu-bar-view.coffee
@@ -10,7 +10,7 @@ module.exports = React.createClass
   componentWillMount: ->
     # need to use direct DOM events because the event needs to be captured
     if window.addEventListener
-      window.addEventListener 'click', @checkBlur, true
+      window.addEventListener 'mousedown', @checkBlur, true
 
     @props.client._ui.listen (event) =>
       switch event.type
@@ -22,7 +22,7 @@ module.exports = React.createClass
 
   componentWillUnmount: ->
     if window.removeEventListener
-      window.removeEventListener 'click', @checkBlur, true
+      window.removeEventListener 'mousedown', @checkBlur, true
 
   getFilename: (props) ->
     if props.filename?.length > 0 then props.filename else (tr "~MENUBAR.UNTITLED_DOCUMENT")


### PR DESCRIPTION
CODAP eats the click events in the main workspace which cause the blur event not to be triggered for the filename rename input element.  This adds a global window listener to simulate the blur event.