### PR TITLE
Improve Safari Local File save [#135154489]

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -485,7 +485,7 @@ class CloudFileManagerClient
       @state.currentContent?.copyMetadataTo envelopedContent
       @_ui.downloadDialog @state.metadata?.name, envelopedContent, callback
 
-  getDownloadUrl: (content, includeShareInfo, mimeType='text/plain') ->
+  getDownloadBlob: (content, includeShareInfo, mimeType='text/plain') ->
     if typeof content is "string"
       if mimeType.indexOf("image") >= 0
         contentToSave = base64Array.toByteArray(content)
@@ -506,13 +506,11 @@ class CloudFileManagerClient
       delete json.metadata.shared if json.metadata?.shared?
       contentToSave = JSON.stringify(json)
 
+    new Blob([contentToSave], {type: mimeType})
+
+  getDownloadUrl: (content, includeShareInfo, mimeType='text/plain') ->
     wURL = window.URL or window.webkitURL
-    downloadUrl = if wURL
-      blob = new Blob([contentToSave], {type: mimeType})
-      wURL.createObjectURL blob
-    else
-      null
-    downloadUrl
+    wURL.createObjectURL(@getDownloadBlob content, includeShareInfo, mimeType) if wURL
 
   rename: (metadata, newName, callback) ->
     dirty = @state.dirty

--- a/src/code/lib/file-saver.js
+++ b/src/code/lib/file-saver.js
@@ -1,0 +1,188 @@
+/* FileSaver.js
+ * A saveAs() FileSaver implementation.
+ * 1.3.2
+ * 2016-06-16 18:25:19
+ *
+ * By Eli Grey, http://eligrey.com
+ * License: MIT
+ *   See https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md
+ */
+
+/*global self */
+/*jslint bitwise: true, indent: 4, laxbreak: true, laxcomma: true, smarttabs: true, plusplus: true */
+
+/*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
+
+var saveAs = saveAs || (function(view) {
+	"use strict";
+	// IE <10 is explicitly unsupported
+	if (typeof view === "undefined" || typeof navigator !== "undefined" && /MSIE [1-9]\./.test(navigator.userAgent)) {
+		return;
+	}
+	var
+		  doc = view.document
+		  // only get URL when necessary in case Blob.js hasn't overridden it yet
+		, get_URL = function() {
+			return view.URL || view.webkitURL || view;
+		}
+		, save_link = doc.createElementNS("http://www.w3.org/1999/xhtml", "a")
+		, can_use_save_link = "download" in save_link
+		, click = function(node) {
+			var event = new MouseEvent("click");
+			node.dispatchEvent(event);
+		}
+		, is_safari = /constructor/i.test(view.HTMLElement) || view.safari
+		, is_chrome_ios =/CriOS\/[\d]+/.test(navigator.userAgent)
+		, throw_outside = function(ex) {
+			(view.setImmediate || view.setTimeout)(function() {
+				throw ex;
+			}, 0);
+		}
+		, force_saveable_type = "application/octet-stream"
+		// the Blob API is fundamentally broken as there is no "downloadfinished" event to subscribe to
+		, arbitrary_revoke_timeout = 1000 * 40 // in ms
+		, revoke = function(file) {
+			var revoker = function() {
+				if (typeof file === "string") { // file is an object URL
+					get_URL().revokeObjectURL(file);
+				} else { // file is a File
+					file.remove();
+				}
+			};
+			setTimeout(revoker, arbitrary_revoke_timeout);
+		}
+		, dispatch = function(filesaver, event_types, event) {
+			event_types = [].concat(event_types);
+			var i = event_types.length;
+			while (i--) {
+				var listener = filesaver["on" + event_types[i]];
+				if (typeof listener === "function") {
+					try {
+						listener.call(filesaver, event || filesaver);
+					} catch (ex) {
+						throw_outside(ex);
+					}
+				}
+			}
+		}
+		, auto_bom = function(blob) {
+			// prepend BOM for UTF-8 XML and text/* types (including HTML)
+			// note: your browser will automatically convert UTF-16 U+FEFF to EF BB BF
+			if (/^\s*(?:text\/\S*|application\/xml|\S*\/\S*\+xml)\s*;.*charset\s*=\s*utf-8/i.test(blob.type)) {
+				return new Blob([String.fromCharCode(0xFEFF), blob], {type: blob.type});
+			}
+			return blob;
+		}
+		, FileSaver = function(blob, name, no_auto_bom) {
+			if (!no_auto_bom) {
+				blob = auto_bom(blob);
+			}
+			// First try a.download, then web filesystem, then object URLs
+			var
+				  filesaver = this
+				, type = blob.type
+				, force = true  // [CC 2016-12-05] type === force_saveable_type
+				, object_url
+				, dispatch_all = function() {
+					dispatch(filesaver, "writestart progress write writeend".split(" "));
+				}
+				// on any filesys errors revert to saving with object URLs
+				, fs_error = function() {
+					if ((is_chrome_ios || (force && is_safari)) && view.FileReader) {
+						// Safari doesn't allow downloading of blob urls
+						var reader = new FileReader();
+						reader.onloadend = function() {
+							var url = is_chrome_ios ? reader.result : reader.result.replace(/^data:[^;]*;/, 'data:attachment/file;');
+							var popup = view.open(url, '_blank');
+							if(!popup) view.location.href = url;
+							url=undefined; // release reference before dispatching
+							filesaver.readyState = filesaver.DONE;
+							dispatch_all();
+						};
+						reader.readAsDataURL(blob);
+						filesaver.readyState = filesaver.INIT;
+						return;
+					}
+					// don't create more object URLs than needed
+					if (!object_url) {
+						object_url = get_URL().createObjectURL(blob);
+					}
+					if (force) {
+						view.location.href = object_url;
+					} else {
+						var opened = view.open(object_url, "_blank");
+						if (!opened) {
+							// Apple does not allow window.open, see https://developer.apple.com/library/safari/documentation/Tools/Conceptual/SafariExtensionGuide/WorkingwithWindowsandTabs/WorkingwithWindowsandTabs.html
+							view.location.href = object_url;
+						}
+					}
+					filesaver.readyState = filesaver.DONE;
+					dispatch_all();
+					revoke(object_url);
+				}
+			;
+			filesaver.readyState = filesaver.INIT;
+
+			if (can_use_save_link) {
+				object_url = get_URL().createObjectURL(blob);
+				setTimeout(function() {
+					save_link.href = object_url;
+					save_link.download = name;
+					click(save_link);
+					dispatch_all();
+					revoke(object_url);
+					filesaver.readyState = filesaver.DONE;
+				});
+				return;
+			}
+
+			fs_error();
+		}
+		, FS_proto = FileSaver.prototype
+		, saveAs = function(blob, name, no_auto_bom) {
+			return new FileSaver(blob, name || blob.name || "download", no_auto_bom);
+		}
+	;
+	// IE 10+ (native saveAs)
+	if (typeof navigator !== "undefined" && navigator.msSaveOrOpenBlob) {
+		return function(blob, name, no_auto_bom) {
+			name = name || blob.name || "download";
+
+			if (!no_auto_bom) {
+				blob = auto_bom(blob);
+			}
+			return navigator.msSaveOrOpenBlob(blob, name);
+		};
+	}
+
+	FS_proto.abort = function(){};
+	FS_proto.readyState = FS_proto.INIT = 0;
+	FS_proto.WRITING = 1;
+	FS_proto.DONE = 2;
+
+	FS_proto.error =
+	FS_proto.onwritestart =
+	FS_proto.onprogress =
+	FS_proto.onwrite =
+	FS_proto.onabort =
+	FS_proto.onerror =
+	FS_proto.onwriteend =
+		null;
+
+	return saveAs;
+}(
+	   typeof self !== "undefined" && self
+	|| typeof window !== "undefined" && window
+	|| this.content
+));
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports.saveAs = saveAs;
+} else if ((typeof define !== "undefined" && define !== null) && (define.amd !== null)) {
+  define("FileSaver.js", function() {
+    return saveAs;
+  });
+}

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -50,7 +50,7 @@ module.exports =
   "~FILE_DIALOG.LOADING": "Loading..."
   "~FILE_DIALOG.LOAD_FOLDER_ERROR": "*** Error loading folder contents ***"
   "~FILE_DIALOG.DOWNLOAD": "Download"
-  "~FILE_DIALOG.DOWNLOAD_NOTE": "NOTE: Mac Safari users may need to control-click the %{download} button"
+  "~FILE_DIALOG.DOWNLOAD_NOTE": "NOTE: On Safari file may be \"Unknown\" and should be manually renamed with a .codap extension."
 
 
   "~DOWNLOAD_DIALOG.DOWNLOAD": "Download"

--- a/src/style/components/file-dialog.styl
+++ b/src/style/components/file-dialog.styl
@@ -66,7 +66,7 @@
 .localFileSave
   .saveArea
     margin-top 10px
-    height 250px
+    height 232px
     color #000
     .shareCheckbox
       input[type=checkbox]


### PR DESCRIPTION
On Safari, behavior is to automatically download the file with name "Unknown". Due to limitations of Safari, this seems to be the best we can do. To accomplish this we introduce the FileSaver.js library (https://github.com/eligrey/FileSaver.js) which attempts to provide the best cross-browser support possible.

If the 'download' attribute is supported, uses the original code to download the file. If the 'download' attribute is not supported (e.g. Safari), uses the FileSaver.js library to perform the download. WebKit Nightly and the Safari Technology Preview both support the 'download' attribute, so the FileSaver.js library will only be necessary for a limited time.

In conjunction with a change to CODAP to allow import of files without extensions, CODAP will be able to open downloaded "Unknown" files even if they are not manuallly renamed.

Finally, we fix the behavior of the "Save Link As..." context menu item on supported browsers, i.e. not current versions of Safari.