### PR TITLE
Validate document contents when opening a file [#134091043]

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -189,6 +189,9 @@ class CloudFileManagerClient
     if metadata?.provider?.can 'load', metadata
       metadata.provider.load metadata, (err, content) =>
         return @alert(err, => @ready()) if err
+        if @appOptions.validator and not @appOptions.validator(content?.getClientContent())
+          invalidMessage = @appOptions.validatorError or tr('~ALERT.INVALID_FILE')
+          return @alert(invalidMessage, => @ready())
         # should wait to close current file until client signals open is complete
         @_closeCurrentFile()
         @_fileOpened content, metadata, {openedContent: content.clone()}, @_getHashParams metadata

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -102,6 +102,7 @@ module.exports =
   "~ALERT_DIALOG.CLOSE": "Close"
 
   "~ALERT.NO_PROVIDER": "Could not open the specified document because an appropriate provider is not available."
+  "~ALERT.INVALID_FILE": "Could not open the specified file because it is not a valid document."
 
   "~DOCSTORE.LOAD_403_ERROR": "You don't have permission to load %{filename}.<br><br>If you are using some else's shared document it may have been unshared."
   "~DOCSTORE.LOAD_SHARED_404_ERROR": "Unable to load the requested shared document.<br><br>Perhaps the file was not shared?"


### PR DESCRIPTION
CFM client can pass a validator() function as part of CFM configuration. If an opened document fails validation then an error alert is shown instead of opening the file. The error message can also be specified by the CFM client, but if not specified a default message will be shown.