### PR TITLE
Fix local file tab drop handling

### DIFF
--- a/src/code/views/local-file-tab-list-view.coffee
+++ b/src/code/views/local-file-tab-list-view.coffee
@@ -6,6 +6,16 @@ module.exports = React.createClass
 
   displayName: 'LocalFileListTab'
 
+  # Standard React 'drop' event handlers are triggered after client 'drop' event handlers.
+  # By explicitly installing DOM event handlers we get first crack at the 'drop' event.
+  componentDidMount: ->
+    @refs.dropZone.addEventListener 'drop', @drop
+    return
+
+  componentWillUnmount: ->
+    @refs.dropZone.removeEventListener 'drop', @drop
+    return
+
   getInitialState: ->
     hover: false
 
@@ -40,16 +50,19 @@ module.exports = React.createClass
 
   drop: (e) ->
     e.preventDefault()
+    e.stopPropagation()
     droppedFiles = if e.dataTransfer then e.dataTransfer.files else e.target.files
     if droppedFiles.length > 1
       @props.client.alert tr "~LOCAL_FILE_DIALOG.MULTIPLE_FILES_DROPPED"
     else if droppedFiles.length is 1
       @openFile droppedFiles[0], 'drop'
+    return
 
   render: ->
     dropClass = "dropArea#{if @state.hover then ' dropHover' else ''}"
     (div {className: 'dialogTab localFileLoad'},
-      (div {className: dropClass, onDragEnter: @dragEnter, onDragLeave: @dragLeave, onDrop: @drop},
+      # 'drop' event handler installed as DOM event handler in componentDidMount()
+      (div {ref: 'dropZone', className: dropClass, onDragEnter: @dragEnter, onDragLeave: @dragLeave},
         (tr "~LOCAL_FILE_DIALOG.DROP_FILE_HERE")
         (input {type: 'file', onChange: @changed})
       )


### PR DESCRIPTION
While testing CFM PR #75 (validate document contents) I encountered the fact that files dropped in the drop zone weren't giving the expected error alert message. This turned out to be because the CODAP document drop handler was handling the 'drop' event before the React onDrop() handler. It had been noticed (but not investigated) previously that dropping a file in this dialog sometimes behaved differently than selecting a file from the file chooser and this is presumably the reason for such discrepancies. The fix is to install a DOM event handler on the element rather than using the React onDrop() mechanism.