### PR TITLE
LaraProvider should disable autosave with read-only access key (again)

### DIFF
--- a/src/code/providers/lara-provider.coffee
+++ b/src/code/providers/lara-provider.coffee
@@ -78,7 +78,7 @@ class LaraProvider extends ProviderInterface
   can: (capability, metadata) ->
     hasReadOnlyAccess = metadata?.providerData?.accessKeys?.readOnly? and
                         not metadata?.providerData?.accessKeys?.readWrite?
-    requiresWriteAccess = ['save', 'remove', 'rename'].indexOf(capability) >= 0
+    requiresWriteAccess = ['save', 'resave', 'remove', 'rename'].indexOf(capability) >= 0
     super(capability, metadata) and not (requiresWriteAccess and hasReadOnlyAccess)
 
   load: (metadata, callback) ->


### PR DESCRIPTION
@scytacki did all the hard work:

> When viewing one of these read-only links, when the user makes a change (or if the data interactive triggers a change). Then the error message:
> "Unable to save undefined: [error.missingParam]" is shown.
> 
> In this document the data interactive causes CODAP to try to autosave right away.  This issue was fixed previously in this PR: https://github.com/concord-consortium/cloud-file-manager/pull/58.

> I think it is caused by the change to 'resave' [here](https://github.com/concord-consortium/cloud-file-manager/blob/master/src/code/client.coffee#L339)
> Which wasn't added [here](https://github.com/concord-consortium/cloud-file-manager/blob/master/src/code/providers/lara-provider.coffee#L81)