### PR TITLE
React build improvements

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -6,6 +6,7 @@ var argv = require('yargs').argv,
     dest  = argv.dest ? argv.dest : './dist', // configure destination folder
     noMap = !!argv.noMap,       // don't generate .map files
     nojQuery = !!argv.nojQuery, // don't include jQuery
+    noReact = !!argv.noReact, // don't include React
     codap = !!argv.codap,       // include CODAP-specific modifications
     assetsSrc = codap ? src + '/assets/img/*.*' : src + '/assets/**/*.*',
     assetsDst = codap ? dest + '/img/' : dest;
@@ -14,6 +15,7 @@ module.exports = {
   flags: {
     noMap: noMap,
     nojQuery: nojQuery,
+    noReact: noReact,
     codap: codap
   },
   browserify: {

--- a/gulp/tasks/browserify-task.js
+++ b/gulp/tasks/browserify-task.js
@@ -14,6 +14,7 @@ var config      = require('../config').browserify;
 var flags       = require('../config').flags;
 var noMap       = flags && flags.noMap;
 var nojQuery    = flags && flags.nojQuery;
+var noReact     = flags && flags.noReact;
 var codap       = flags && flags.codap;
 var beep        = require('beepbeep');
 
@@ -51,6 +52,10 @@ gulp.task('browserify-globals', function(){
   if(nojQuery) {
     b.exclude('jquery');
   }
+  if(noReact) {
+    b.exclude('react');
+    b.exclude('react-dom');
+  }
   b.transform(coffeeify);
   b.add(config.globals.src);
   return b.bundle()
@@ -58,6 +63,10 @@ gulp.task('browserify-globals', function(){
     .pipe(source('globals.js'))
     .pipe(buffer())
     .pipe(gulpif(nojQuery, replace(/.*?(jQuery|global\.\$)\s*=.*\n?/g,
+                                    function(iMatch) {
+                                      return '//' + iMatch;
+                                    })))
+    .pipe(gulpif(noReact, replace(/.*?(React|ReactDOM)\s*=.*\n?/g,
                                     function(iMatch) {
                                       return '//' + iMatch;
                                     })))

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "js-base64": "^2.1.9",
     "lodash": "^3.3.0",
     "pako": "^1.0.1",
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
     "svg-social-icons": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "build": "gulp clean-and-build",
-    "build:codap": "gulp clean-and-build --dest ../codap/apps/dg/resources/cloud-file-manager --codap --nojQuery --noMap",
+    "build:codap": "gulp clean-and-build --dest ../codap/apps/dg/resources/cloud-file-manager --codap --nojQuery --noReact --noMap",
     "build:watch": "gulp",
     "deploy": "gulp deploy",
     "serve": "live-server --open=dist/examples"


### PR DESCRIPTION
- upgrade React to version 15.4.1
- add --noReact option to exclude React/ReactDOM from globals.js
- modify `build:codap` script to specify --noReact option
