### PR TITLE
Eliminate react warnings

### DIFF
--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -12,8 +12,7 @@ GoogleDriveAuthorizationDialog = React.createFactory React.createClass
   displayName: 'GoogleDriveAuthorizationDialog'
 
   getInitialState: ->
-    @_hasLoadedGAPI = false
-    loadedGAPI: false
+    loadedGAPI: window._LoadedGAPIClients
 
   # See comments in AuthorizeMixin for detailed description of the issues here.
   # The short version is that we need to maintain synchronized instance variable
@@ -22,14 +21,13 @@ GoogleDriveAuthorizationDialog = React.createFactory React.createClass
 
   componentWillMount: ->
     @props.provider._loadedGAPI =>
-      @_hasLoadedGAPI = true
       if @_isMounted
         @setState loadedGAPI: true
 
   componentDidMount: ->
     @_isMounted = true
-    if @state.loadedGAPI isnt @_hasLoadedGAPI
-      @setState loadedGAPI: @_hasLoadedGAPI
+    if @state.loadedGAPI isnt window._LoadedGAPIClients
+      @setState loadedGAPI: window._LoadedGAPIClients
 
   componentWillUnmount: ->
     @_isMounted = false
@@ -41,7 +39,7 @@ GoogleDriveAuthorizationDialog = React.createFactory React.createClass
     (div {className: 'google-drive-auth'},
       (div {className: 'google-drive-concord-logo'}, '')
       (div {className: 'google-drive-footer'},
-        if @_hasLoadedGAPI or @state.loadedGAPI
+        if window._LoadedGAPIClients or @state.loadedGAPI
           (button {onClick: @authenticate}, (tr "~GOOGLE_DRIVE.LOGIN_BUTTON_LABEL"))
         else
           (tr "~GOOGLE_DRIVE.CONNECTING_MESSAGE")

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -42,9 +42,9 @@ GoogleDriveAuthorizationDialog = React.createFactory React.createClass
       (div {className: 'google-drive-concord-logo'}, '')
       (div {className: 'google-drive-footer'},
         if @_hasLoadedGAPI or @state.loadedGAPI
-          (button {onClick: @authenticate}, 'Login to Google')
+          (button {onClick: @authenticate}, (tr "~GOOGLE_DRIVE.LOGIN_BUTTON_LABEL"))
         else
-          'Connecting to Google...'
+          (tr "~GOOGLE_DRIVE.CONNECTING_MESSAGE")
       )
     )
 
@@ -70,7 +70,7 @@ class GoogleDriveProvider extends ProviderInterface
     @user = null
     @clientId = @options.clientId
     if not @clientId
-      throw new Error 'Missing required clientId in googleDrive provider options'
+      throw new Error (tr "~GOOGLE_DRIVE.ERROR_MISSING_CLIENTID")
     @mimeType = @options.mimeType or "text/plain"
     @readableMimetypes = @options.readableMimetypes
     @useRealTimeAPI = @options.useRealTimeAPI or false

--- a/src/code/utils/lang/en-us.coffee
+++ b/src/code/utils/lang/en-us.coffee
@@ -103,6 +103,10 @@ module.exports =
 
   "~ALERT.NO_PROVIDER": "Could not open the specified document because an appropriate provider is not available."
 
+  "~GOOGLE_DRIVE.LOGIN_BUTTON_LABEL": "Login to Google"
+  "~GOOGLE_DRIVE.CONNECTING_MESSAGE": "Connecting to Google..."
+  "~GOOGLE_DRIVE.ERROR_MISSING_CLIENTID": "Missing required clientId in googleDrive provider options"
+
   "~DOCSTORE.LOAD_403_ERROR": "You don't have permission to load %{filename}.<br><br>If you are using some else's shared document it may have been unshared."
   "~DOCSTORE.LOAD_SHARED_404_ERROR": "Unable to load the requested shared document.<br><br>Perhaps the file was not shared?"
   "~DOCSTORE.LOAD_404_ERROR": "Unable to load %{filename}"

--- a/src/code/views/authorize-mixin.coffee
+++ b/src/code/views/authorize-mixin.coffee
@@ -1,13 +1,52 @@
 AuthorizeMixin =
   getInitialState: ->
+    _isAuthorized = false
     authorized: false
 
+  # The constraints here are somewhat subtle. We want to try to
+  # determine whether the user is authorized before the first render,
+  # because authorization status can affect rendering. Thus, we want
+  # to perform the check in componentWillMount(). Some providers
+  # can/will respond immediately, either because they don't require
+  # authorization or because they are already authorized. Unfortunately,
+  # setState() can't be called in componentWillMount(), so if we get
+  # an immediate response, we need to store it in an instance variable.
+  # Then in componentDidMount(), we can propagate the instance variable
+  # to the state via a call to setState(). Some providers will need to
+  # make an asynchronous call to determine authorization status. This
+  # call may complete before or after the first render, i.e. before or
+  # after the componentDidMount() method. Once the component is mounted,
+  # the call to setState() is required to set the state and trigger a
+  # re-render. In the end we need to maintain both the instance variable
+  # and the state to track the authorization status, render the appropriate
+  # authorization status, and re-render when authorization status changes.
+
   componentWillMount: ->
+    # Check for authorization before the first render. Providers that
+    # don't require authorization or are already authorized will respond
+    # immediately, but since the component isn't mounted yet we can't
+    # call setState, so we set an instance variable and update state
+    # in componentDidMount(). Providers that require asynchronous checks
+    # for authorization may return before or after the first render, so
+    # code should be prepared for either eventuality.
     @props.provider.authorized (authorized) =>
-      @setState authorized: authorized
+      # always set the instance variable
+      @_isAuthorized = authorized
+      # set the state if we can
+      if @_isMounted
+        @setState authorized: authorized
+
+  componentDidMount: ->
+    @_isMounted = true
+    # synchronize state if necessary
+    if @state.authorized isnt @_isAuthorized
+      @setState authorized: @_isAuthorized
+
+  componentWillUnmount: ->
+    @_isMounted = false
 
   render: ->
-    if @state.authorized
+    if @_isAuthorized or @state.authorized
       @renderWhenAuthorized()
     else
       @props.provider.renderAuthorizationDialog()


### PR DESCRIPTION
Eliminate `setState called on unmounted component` React warnings
- use synchronized instance variable and state variable in GoogleDriveProvider and AuthorizeMixin
- added _isMounted instance variable to handle cases in which component is unmounted when asynchronous call returns

I didn't make the corresponding changes in the DocumentStoreProvider, since that's going away imminently.

Note: It's possible that some of the Google Drive authorization-related oddities that have been reported could be affected by authorization state-handling, so some testing of those issues would make sense.