### PR TITLE
Hamburger menu too close to doc name for touch

### DIFF
--- a/src/style/components/dropdown-menu.styl
+++ b/src/style/components/dropdown-menu.styl
@@ -4,6 +4,7 @@
   .menu-anchor
     display inline-block
     cursor pointer
+    padding-right 10px
     svg
       fill #fff
 

--- a/src/style/components/menu-bar.styl
+++ b/src/style/components/menu-bar.styl
@@ -16,7 +16,7 @@
   .menu-bar-content-filename
     label-font(size: 13px, transform: none)
     display inline-block
-    padding-left 10px
+    padding-left 5px
     padding-top 1px
     cursor pointer
     no-select()


### PR DESCRIPTION
Fixes [#137658223] (from Bill Finzer, who originally made the change locally within CODAP)
Increase padding-right for the menu and decrease padding-left for the file menu
