### PR TITLE
Fixed missing export of production flag in config

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -12,6 +12,7 @@ var argv = require('yargs').argv,
     assetsDst = codap ? dest + '/img/' : dest;
 
 module.exports = {
+  production: production,
   flags: {
     noMap: noMap,
     nojQuery: nojQuery,


### PR DESCRIPTION
This was causing the the browserify tasks to include sourcemaps in production builds.