### PR TITLE
Fixed CORs auth server response bug in IE 11 [#149863936]

### DIFF
--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -247,14 +247,15 @@ class GoogleDriveProvider extends ProviderInterface
             provider: @
             providerData:
               id: file.parents[0].id
+        url = file.downloadUrl
+        # use access_token as query parameter instead of header to avoid CORS request which breaks in IE 11
+        url += "#{if url.indexOf("?") is -1 then "?" else "&"}access_token=#{encodeURIComponent(@authToken.access_token)}"
         xhr = new XMLHttpRequest()
-        xhr.open 'GET', file.downloadUrl
-        if @authToken
-          xhr.setRequestHeader 'Authorization', "Bearer #{@authToken.access_token}"
+        xhr.open 'GET', url
         xhr.onload = ->
           callback null, cloudContentFactory.createEnvelopedCloudContent xhr.responseText
         xhr.onerror = ->
-          callback "Unable to download #{url}"
+          callback "Unable to download file content"
         xhr.send()
       else
         callback @_apiError file, 'Unable to get download url'


### PR DESCRIPTION
Changed the file download to specify the access_token as a query parameter instead of request header.  This avoids a CORS OPTIONS request which fails in IE 11 because the server response for the accept-header from Google is longer than 1024 bytes.