### PR TITLE
"Headless" CFM

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -1,6 +1,7 @@
 tr = require './utils/translate'
 isString = require './utils/is-string'
 base64Array = require 'base64-js' # https://github.com/beatgammit/base64-js
+getQueryParam = require './utils/get-query-param'
 
 CloudFileManagerUI = (require './ui').CloudFileManagerUI
 
@@ -11,6 +12,7 @@ LaraProvider = require './providers/lara-provider'
 DocumentStoreProvider = require './providers/document-store-provider'
 DocumentStoreShareProvider = require './providers/document-store-share-provider'
 LocalFileProvider = require './providers/local-file-provider'
+PostMessageProvider = require './providers/post-message-provider'
 URLProvider = require './providers/url-provider'
 
 cloudContentFactory = (require './providers/provider-interface').cloudContentFactory
@@ -39,7 +41,16 @@ class CloudFileManagerClient
 
     # filter for available providers
     allProviders = {}
-    for Provider in [ReadOnlyProvider, LocalStorageProvider, GoogleDriveProvider, LaraProvider, DocumentStoreProvider, LocalFileProvider]
+    providerList = [
+      LocalStorageProvider
+      ReadOnlyProvider
+      GoogleDriveProvider
+      LaraProvider
+      DocumentStoreProvider
+      LocalFileProvider
+      PostMessageProvider
+    ]
+    for Provider in providerList
       if Provider.Available()
         allProviders[Provider.Name] = Provider
 
@@ -58,10 +69,15 @@ class CloudFileManagerClient
     readableMimetypes.push @appOptions.mimeType
 
     # check the providers
+    requestedProviders = @appOptions.providers.slice()
+    if getQueryParam "saveSecondaryFileViaPostMessage"
+      requestedProviders.push 'postMessage'
     availableProviders = []
     shareProvider = null
-    for provider in @appOptions.providers
-      [providerName, providerOptions] = if isString provider then [provider, {}] else [provider.name, provider]
+    for providerSpec in requestedProviders
+      [providerName, providerOptions] = if isString providerSpec \
+                                          then [providerSpec, {}] \
+                                          else [providerSpec.name, providerSpec]
       # merge in other options as needed
       providerOptions.mimeType ?= @appOptions.mimeType
       providerOptions.readableMimetypes = readableMimetypes
@@ -154,6 +170,10 @@ class CloudFileManagerClient
   listen: (listener) ->
     if listener
       @_listeners.push listener
+
+  autoProvider: (capability) ->
+    for provider in @state.availableProviders
+      return provider if provider.canAuto capability
 
   appendMenuItem: (item) ->
     @_ui.appendMenuItem item; @
@@ -329,7 +349,7 @@ class CloudFileManagerClient
       @saveContent stringContent, callback
 
   saveContent: (stringContent, callback = null) ->
-    provider = @state.metadata?.provider
+    provider = @state.metadata?.provider or @autoProvider 'save'
     if provider?
       provider.authorized (isAuthorized) =>
         # we can save the document without authorization in some cases
@@ -554,13 +574,9 @@ class CloudFileManagerClient
       callback? 'No initial opened version was found for the currently active file'
 
   saveSecondaryFileAsDialog: (stringContent, extension, mimeType, callback) ->
-    if window.location.search.indexOf("saveSecondaryFileViaPostMessage") isnt -1
-      window.parent.postMessage({
-        action: "saveSecondaryFile",
-        extension: extension,
-        mimeType: mimeType,
-        content: stringContent
-      }, "*")
+    if (provider = @autoProvider 'export')
+      metadata = { provider, extension, mimeType }
+      @saveSecondaryFile stringContent, metadata, callback
     else
       data = { content: stringContent, extension, mimeType }
       @_ui.saveSecondaryFileAsDialog data, (metadata) =>
@@ -575,15 +591,11 @@ class CloudFileManagerClient
   # Saves a file to backend, but does not update current metadata.
   # Used e.g. when exporting .csv files from CODAP
   saveSecondaryFile: (stringContent, metadata, callback = null) ->
-    if metadata?.provider?.can 'save', metadata
-      @_setState
-        saving: metadata
+    if metadata?.provider?.can 'export', metadata
       metadata.provider.save stringContent, metadata, (err, statusCode) =>
         if err
           return @alert(err)
-        @_setState
-          saving: null
-        callback? currentContent, metadata
+        callback? stringContent, metadata
 
   dirty: (isDirty = true)->
     @_setState

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -59,6 +59,7 @@ class CloudFileManagerClient
 
     # check the providers
     availableProviders = []
+    shareProvider = null
     for provider in @appOptions.providers
       [providerName, providerOptions] = if isString provider then [provider, {}] else [provider.name, provider]
       # merge in other options as needed
@@ -71,6 +72,9 @@ class CloudFileManagerClient
           Provider = allProviders[providerName]
           provider = new Provider providerOptions, @
           @providers[providerName] = provider
+          # if we're using the DocumentStoreProvider, instantiate the ShareProvider
+          if providerName is DocumentStoreProvider.Name
+            shareProvider = new DocumentStoreShareProvider(@, provider)
           if provider.urlDisplayName        # also add to here in providers list so we can look it up when parsing url hash
             @providers[provider.urlDisplayName] = provider
           availableProviders.push provider
@@ -78,7 +82,7 @@ class CloudFileManagerClient
           @alert "Unknown provider: #{providerName}"
     @_setState
       availableProviders: availableProviders
-      shareProvider: new DocumentStoreShareProvider(@, @providers[DocumentStoreProvider.Name])
+      shareProvider: shareProvider
 
     @appOptions.ui or= {}
     @appOptions.ui.windowTitleSuffix or= document.title

--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -39,7 +39,8 @@ class CloudFileManagerClient
     @appOptions.wrapFileContent ?= true
     CloudContent.wrapFileContent = @appOptions.wrapFileContent
 
-    # filter for available providers
+    # Determine the available providers. Note that order in the list can
+    # be significant in provider searches (e.g. @autoProvider).
     allProviders = {}
     providerList = [
       LocalStorageProvider
@@ -592,7 +593,7 @@ class CloudFileManagerClient
   # Used e.g. when exporting .csv files from CODAP
   saveSecondaryFile: (stringContent, metadata, callback = null) ->
     if metadata?.provider?.can 'export', metadata
-      metadata.provider.save stringContent, metadata, (err, statusCode) =>
+      metadata.provider.saveAsExport stringContent, metadata, (err, statusCode) =>
         if err
           return @alert(err)
         callback? stringContent, metadata

--- a/src/code/providers/post-message-provider.coffee
+++ b/src/code/providers/post-message-provider.coffee
@@ -19,7 +19,7 @@ class PostMessageProvider extends ProviderInterface
 
   canOpenSaved: -> false
 
-  save: (content, metadata, callback) ->
+  saveAsExport: (content, metadata, callback) ->
     window.parent.postMessage({
       action: "saveSecondaryFile",
       extension: metadata.extension,

--- a/src/code/providers/post-message-provider.coffee
+++ b/src/code/providers/post-message-provider.coffee
@@ -1,0 +1,31 @@
+ProviderInterface = (require './provider-interface').ProviderInterface
+getQueryParam = require '../utils/get-query-param'
+
+class PostMessageProvider extends ProviderInterface
+
+  @Name: 'postMessage'
+
+  constructor: (@options = {}, @client) ->
+    super
+      capabilities:
+        save: false
+        resave: false
+        export: if getQueryParam "saveSecondaryFileViaPostMessage" then 'auto' else false
+        load: false
+        list: false
+        remove: false
+        rename: false
+        close: false
+
+  canOpenSaved: -> false
+
+  save: (content, metadata, callback) ->
+    window.parent.postMessage({
+      action: "saveSecondaryFile",
+      extension: metadata.extension,
+      mimeType: metadata.mimeType,
+      content: content
+    }, "*")
+    callback? null
+
+module.exports = PostMessageProvider

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -202,6 +202,13 @@ class ProviderInterface
   save: (content, metadata, callback) ->
     @_notImplemented 'save'
 
+  saveAsExport: (content, metadata, callback) ->
+    # default implementation invokes save
+    if @can 'save', metadata
+      @save content, metadata, callback
+    else
+      @_notImplemented 'saveAsExport'
+
   load: (callback) ->
     @_notImplemented 'load'
 

--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -158,7 +158,10 @@ class ProviderInterface
   @Available: -> true
 
   can: (capability) ->
-    @capabilities[capability]
+    !!@capabilities[capability]
+
+  canAuto: (capability) ->
+    @capabilities[capability] is 'auto'
 
   isAuthorizationRequired: ->
     false


### PR DESCRIPTION
Make it easier for third parties (e.g. Zoom In Science) to work with CFM:
- eliminate hard-coded provider dependencies
- make it possible to avoid user-facing dialogs with appropriate providers

Only instantiate `DocumentStoreShareProvider` when using the `DocumentStoreProvider` [#152333125]

Add `autoProvider` architecture
- providers can support a capability without user intervention (i.e. without dialogs)
- `saveContent()` and `saveSecondaryFileAsDialog()` methods check for `autoProvider` [#152332814]
- move `saveSecondaryFileViaPostMessage` capability into new PostMessageProvider
