### PR TITLE
add `run_remote_endpoint` from interactive run state to `logLaraData` [#151493565]

### DIFF
--- a/src/code/providers/lara-provider.coffee
+++ b/src/code/providers/lara-provider.coffee
@@ -285,7 +285,7 @@ class LaraProvider extends ProviderInterface
               documentID: docStore.recordid
               documentUrl: url
             }
-            laraData.remoteEndpoint = existingRunState.run_remote_endpoint if existingRunState?.run_remote_endpoint?
+            laraData.run_remote_endpoint = existingRunState.run_remote_endpoint if existingRunState?.run_remote_endpoint?
             @logLaraData laraData
             processCreateResponse createResponse
             callback null
@@ -405,7 +405,7 @@ class LaraProvider extends ProviderInterface
           runStateUrl: openSavedParams.url
           documentID: openSavedParams.source
         }
-        laraData.remoteEndpoint = data.run_remote_endpoint if data?.run_remote_endpoint?
+        laraData.run_remote_endpoint = data.run_remote_endpoint if data?.run_remote_endpoint?
         @logLaraData laraData
         processInitialRunState openSavedParams.url, openSavedParams.source, openSavedParams.readOnlyKey, data
       .fail (jqXHR, status, error) ->

--- a/src/code/providers/lara-provider.coffee
+++ b/src/code/providers/lara-provider.coffee
@@ -280,11 +280,13 @@ class LaraProvider extends ProviderInterface
             dataType: 'json'
           })
           .done (createResponse, status, jqXHR) =>
-            @logLaraData {
+            laraData = {
               operation: 'clone'
               documentID: docStore.recordid
               documentUrl: url
             }
+            laraData.remoteEndpoint = existingRunState.run_remote_endpoint if existingRunState?.run_remote_endpoint?
+            @logLaraData laraData
             processCreateResponse createResponse
             callback null
           .fail (jqXHR, status, error) ->
@@ -398,11 +400,13 @@ class LaraProvider extends ProviderInterface
           withCredentials: true
       })
       .done (data, status, jqXHR) =>
-        @logLaraData {
+        laraData = {
           operation: 'open'
           runStateUrl: openSavedParams.url
           documentID: openSavedParams.source
         }
+        laraData.remoteEndpoint = data.run_remote_endpoint if data?.run_remote_endpoint?
+        @logLaraData laraData
         processInitialRunState openSavedParams.url, openSavedParams.source, openSavedParams.readOnlyKey, data
       .fail (jqXHR, status, error) ->
         callback "Could not open the specified document because an error occurred [getState]"


### PR DESCRIPTION
Note: I'm not set up to run LARA locally, so I've written this code on spec but haven't had a chance to test it yet. The results won't appear in the CODAP logs until the corresponding [CODAP PR](https://github.com/concord-consortium/codap/pull/210) is merged as well.