### PR TITLE
Support logging callback

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -175,6 +175,10 @@ class CloudFileManagerClient
     if listener
       @_listeners.push listener
 
+  log: (event, eventData) ->
+    if (@appOptions.log)
+      @appOptions.log event, eventData
+
   autoProvider: (capability) ->
     for provider in @state.availableProviders
       return provider if provider.canAuto capability

--- a/src/code/providers/document-store-provider.coffee
+++ b/src/code/providers/document-store-provider.coffee
@@ -308,12 +308,25 @@ class DocumentStoreProvider extends ProviderInterface
     if @urlParams.runKey
       params.runKey = @urlParams.runKey
 
-    $.ajax
-      dataType: 'json'
-      type: 'POST'
-      url: if patchResults.shouldPatch \
+    method = 'POST'
+    url = if patchResults.shouldPatch \
             then @docStoreUrl.patchDocument(params) \
             else @docStoreUrl.saveDocument(params)
+
+    logData =
+      operation: 'save'
+      provider: 'DocumentStoreProvider'
+      shouldPatch: patchResults.shouldPatch
+      method: method
+      url: url
+      params: JSON.stringify(params)
+      content: patchResults.sendContent.substr(0, 512)
+    @client.log 'save', logData
+
+    $.ajax
+      dataType: 'json'
+      type: method
+      url: url
       data: pako.deflate patchResults.sendContent
       contentType: patchResults.mimeType
       processData: false

--- a/src/code/providers/document-store-url.coffee
+++ b/src/code/providers/document-store-url.coffee
@@ -9,6 +9,8 @@ class DocumentStoreUrl
 
   constructor: (docStoreUrl) ->
     @docStoreUrl = docStoreUrl or defaultDocStoreUrl
+    # eliminate trailing slashes
+    @docStoreUrl = @docStoreUrl.replace(/\/+$/, '')
 
   addParams: (url, params) ->
     return url unless params

--- a/src/code/providers/lara-provider.coffee
+++ b/src/code/providers/lara-provider.coffee
@@ -65,6 +65,7 @@ class LaraProvider extends ProviderInterface
   logLaraData: (laraData) ->
     laraData.collaboratorUrls = @collaboratorUrls if @collaboratorUrls?.length
     @options.logLaraData laraData if @options.logLaraData
+    @client.log 'logLaraData', laraData
 
   # don't show in provider open/save dialogs
   filterTabComponent: (capability, defaultComponent) ->
@@ -145,6 +146,17 @@ class LaraProvider extends ProviderInterface
     {method, url} = if patchResults.shouldPatch \
                       then @docStoreUrl.v2PatchDocument(metadata.providerData.recordid, params) \
                       else @docStoreUrl.v2SaveDocument(metadata.providerData.recordid, params)
+
+    logData =
+      operation: 'save'
+      provider: 'LaraProvider'
+      shouldPatch: patchResults.shouldPatch
+      method: method
+      # elide all but first two chars of accessKey
+      url: url.substr(0, url.indexOf('accessKey') + 16) + '...'
+      params: JSON.stringify({ recordname: params.recordname })
+      content: patchResults.sendContent.substr(0, 512)
+    @client.log 'save', logData
 
     $.ajax
       dataType: 'json'


### PR DESCRIPTION
Support `log` callback for logging through client application [#152333085]
- add `save` logging to `DocumentStoreProvider` and `LaraProvider` for debugging purposes

Eliminate trailing slashes from `@docStoreUrl`
- having recently encountered situations in which redundant slashes caused problems for some servers, we proactively remove the potential problem.

@scytacki Does this look like the right information to log to help with debugging the document corruption issue?