### PR TITLE
Reduce `drive` permission to `drive.readonly`

### DIFF
--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -97,7 +97,7 @@ class GoogleDriveProvider extends ProviderInterface
       args =
         client_id: @clientId
         scope: [
-          'https://www.googleapis.com/auth/drive'
+          'https://www.googleapis.com/auth/drive.readonly'
           'https://www.googleapis.com/auth/drive.install'
           'https://www.googleapis.com/auth/drive.file'
           'https://www.googleapis.com/auth/userinfo.profile'


### PR DESCRIPTION
`drive.readonly` gives us permission to read all files, for the file
dialog, and we already have write permissions to the files we create
through the `drive.file` permission.