### PR TITLE
Authorization is required for Google Drive

### DIFF
--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -206,6 +206,9 @@ class GoogleDriveProvider extends ProviderInterface
   getOpenSavedParams: (metadata) ->
     metadata.providerData.id
 
+  isAuthorizationRequired: ->
+    true
+
   _loadGAPI: ->
     if not window._LoadingGAPI
       window._LoadingGAPI = true


### PR DESCRIPTION
Hi @dougmartin, this is a one-line PR. It tells the CFM that Google Drive always requires authorization, and the existing CFM functionality then kicks in to show the authorization popup before trying to open a file from a url. This is deployed to gh-pages, and demo steps can be seen at the PT story below.

Fixes https://www.pivotaltracker.com/n/projects/1055240/stories/133639103

---

If the user is either

1. not logged into Drive, or
2. has not authorized the app

we will show the authorization dialog.

[#133639103]