### PR TITLE
Update LARA share dialog to use autolaunch page and fullscreen scaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 
 # OS or Editor folders
 .DS_Store
+.idea

--- a/src/code/views/share-dialog-view.coffee
+++ b/src/code/views/share-dialog-view.coffee
@@ -42,11 +42,10 @@ module.exports = React.createClass
   getInitialState: ->
     link: @getShareLink()
     embed: @getEmbed()
-    lara: @getLara
-      codapServerUrl: "https://codap.concord.org/releases/latest/"
-      launchButtonText: "Launch"
+    pageType: "autolaunch"
     codapServerUrl: "https://codap.concord.org/releases/latest/"
     launchButtonText: "Launch"
+    fullscreenScaling: true
     tabSelected: 'link'
 
   getSharedDocumentId: ->
@@ -70,14 +69,15 @@ module.exports = React.createClass
     else
       null
 
-  getLara: (options = null) ->
+  getLara: ->
     sharedDocumentId = @getSharedDocumentId()
     if sharedDocumentId
       documentServer = getQueryParam('documentServer') or 'https://document-store.concord.org'
       documentServer = documentServer.slice(0, -1) while documentServer.substr(-1) is '/'  # remove trailing slash
-      server = encodeURIComponent (if options?.hasOwnProperty('codapServerUrl') then options.codapServerUrl else @state.codapServerUrl)
-      buttonText = encodeURIComponent (if options?.hasOwnProperty('launchButtonText') then options.launchButtonText else @state.launchButtonText)
-      "#{documentServer}/v2/documents/#{sharedDocumentId}/launch?server=#{server}&buttonText=#{buttonText}"
+      server = encodeURIComponent(@state.codapServerUrl)
+      buttonText = if @state.pageType is 'launch' then "&buttonText=#{encodeURIComponent(@state.launchButtonText)}" else ''
+      fullscreenScaling = if @state.pageType is 'autolaunch' and @state.fullscreenScaling then '&scaling' else ''
+      "#{documentServer}/v2/documents/#{sharedDocumentId}/#{@state.pageType}?server=#{server}#{buttonText}#{fullscreenScaling}"
     else
       null
 
@@ -124,7 +124,6 @@ module.exports = React.createClass
       @setState
         link: @getShareLink()
         embed: @getEmbed()
-        lara: @getLara()
 
   selectLinkTab: ->
     @setState tabSelected: 'link'
@@ -135,17 +134,21 @@ module.exports = React.createClass
   selectLaraTab: ->
     @setState tabSelected: 'lara'
 
-  changedCodapServerUrl: ->
-    codapServerUrl = ReactDOM.findDOMNode(@refs.codapServerUrl).value
+  changedCodapServerUrl: (event) ->
     @setState
-      codapServerUrl: codapServerUrl
-      lara: @getLara codapServerUrl: codapServerUrl
+      codapServerUrl: event.target.value
 
-  changedLaunchButtonText: ->
-    launchButtonText = ReactDOM.findDOMNode(@refs.launchButtonText).value
+  changedLaunchButtonText: (event) ->
     @setState
-      launchButtonText: launchButtonText
-      lara: @getLara launchButtonText: launchButtonText
+      launchButtonText: event.target.value
+
+  changedAutoscalingPage: (event) ->
+    @setState
+      pageType: if event.target.checked then 'autolaunch' else 'launch'
+
+  changedFullscreenScaling: (event) ->
+    @setState
+      fullscreenScaling: event.target.checked
 
   render: ->
     sharing = @state.link isnt null
@@ -202,21 +205,29 @@ module.exports = React.createClass
                     if document.execCommand or window.clipboardData
                       (a {className: 'copy-link', href: '#', onClick: @copy}, tr '~SHARE_DIALOG.COPY')
                     (div {},
-                      (input {value: @state.lara, readOnly: true})
+                      (input {value: @getLara(), readOnly: true})
                     )
                     (div {className: 'lara-settings'},
                       (div {className: 'codap-server-url'},
                         "CODAP Server URL:"
                         (div {},
-                          (input {value: @state.codapServerUrl, ref: 'codapServerUrl', onChange: @changedCodapServerUrl})
+                          (input {value: @state.codapServerUrl, onChange: @changedCodapServerUrl})
                         )
                       )
-                      (div {className: 'launch-button-text'},
-                        "Launch Button Text:"
-                        (div {},
-                          (input {value: @state.launchButtonText, ref: 'launchButtonText', onChange: @changedLaunchButtonText})
-                        )
+                      (div {className: 'autolaunch'},
+                        (input {type: 'checkbox', checked: @state.pageType is 'autolaunch', onChange: @changedAutoscalingPage})
+                        "Autolaunch page"
                       )
+                      if @state.pageType is 'autolaunch'
+                        (div {className: 'fullsceen-scaling'},
+                          (input {type: 'checkbox', checked: @state.fullscreenScaling, onChange: @changedFullscreenScaling})
+                          "Fullscreen button and scaling"
+                        )
+                      else
+                        (div {className: 'launch-button-text'},
+                          "Launch Button Text:"
+                          (input {value: @state.launchButtonText, onChange: @changedLaunchButtonText})
+                        )
                     )
                   )
                 else

--- a/src/code/views/share-dialog-view.coffee
+++ b/src/code/views/share-dialog-view.coffee
@@ -46,6 +46,7 @@ module.exports = React.createClass
     codapServerUrl: "https://codap.concord.org/releases/latest/"
     launchButtonText: "Launch"
     fullscreenScaling: true
+    graphVisToggles: false
     tabSelected: 'link'
 
   getSharedDocumentId: ->
@@ -77,7 +78,8 @@ module.exports = React.createClass
       server = encodeURIComponent(@state.codapServerUrl)
       buttonText = if @state.pageType is 'launch' then "&buttonText=#{encodeURIComponent(@state.launchButtonText)}" else ''
       fullscreenScaling = if @state.pageType is 'autolaunch' and @state.fullscreenScaling then '&scaling' else ''
-      "#{documentServer}/v2/documents/#{sharedDocumentId}/#{@state.pageType}?server=#{server}#{buttonText}#{fullscreenScaling}"
+      graphVisToggles = if @state.graphVisToggles then '&app=is' else ''
+      "#{documentServer}/v2/documents/#{sharedDocumentId}/#{@state.pageType}?server=#{server}#{buttonText}#{fullscreenScaling}#{graphVisToggles}"
     else
       null
 
@@ -149,6 +151,10 @@ module.exports = React.createClass
   changedFullscreenScaling: (event) ->
     @setState
       fullscreenScaling: event.target.checked
+
+  changedGraphVisToggles: (event) ->
+    @setState
+      graphVisToggles: event.target.checked
 
   render: ->
     sharing = @state.link isnt null
@@ -223,11 +229,15 @@ module.exports = React.createClass
                           (input {type: 'checkbox', checked: @state.fullscreenScaling, onChange: @changedFullscreenScaling})
                           "Fullscreen button and scaling"
                         )
-                      else
+                      if @state.pageType is 'launch'
                         (div {className: 'launch-button-text'},
                           "Launch Button Text:"
                           (input {value: @state.launchButtonText, onChange: @changedLaunchButtonText})
                         )
+                      (div {},
+                        (input {type: 'checkbox', checked: @state.graphVisToggles, onChange: @changedGraphVisToggles})
+                        "Display data visibility toggles on graphs"
+                      )
                     )
                   )
                 else

--- a/src/style/components/share-dialog.styl
+++ b/src/style/components/share-dialog.styl
@@ -46,7 +46,6 @@
   .sharing-tab-contents
     clear both
     padding 20px
-    height 100px
     background-color #ddd
     border-top 1px solid #000
     border-bottom 1px solid #000
@@ -105,10 +104,12 @@
       margin-top 10px
       .codap-server-url
         width 68%
-        float left
-      .launch-button-text
-        width 30%
-        float right
+      .launch-button-text input
+        width: 160px !important
+        margin-left: 10px;
+      input[type="checkbox"]
+        margin-right: 10px;
+        width: 10px !important
 
   .buttons
     clear both


### PR DESCRIPTION
Changes:
- switch default page to "autolaunch"
- add "autolaunch" / "launch" page checkbox
- add "fullscreen scaling" checkbox (it passes "scaling" URL param to doc-server, which modifies CODAP iframe to scale down and include fullscreen button)
- display inputs bases on page tyle (Launch Button Text for "launch" page, scaling for "autolaunch")
- cleanup and simplify some related code (e.g. `lara` state was redundant, it can be generated using other properties; simplify some event handlers, remove refs)

Screenshots:
<img width="626" alt="screen shot 2018-03-23 at 16 45 11" src="https://user-images.githubusercontent.com/767857/37857599-a095357c-2eb9-11e8-96c4-fbf51c975ce2.png">
<img width="621" alt="screen shot 2018-03-23 at 16 45 18" src="https://user-images.githubusercontent.com/767857/37857600-a0ab330e-2eb9-11e8-9c5e-078dd4954f24.png">

@dougmartin or @kswenson, could you take a look? @dougmartin seems to be the main contributor, but @kswenson works on IS2 project. 😉 
