### PR TITLE
Fix copy link in LARA share dialog

### DIFF
--- a/src/code/views/share-dialog-view.coffee
+++ b/src/code/views/share-dialog-view.coffee
@@ -87,7 +87,10 @@ module.exports = React.createClass
   copy: (e) ->
     e.preventDefault()
     copied = false
-    toCopy = @state[@state.tabSelected]
+    toCopy = switch @state.tabSelected
+      when 'embed' then @getEmbed()
+      when 'link' then @getShareLink()
+      when 'lara' then @getLara()
     try
       mark = document.createElement 'mark'
       mark.innerText = toCopy

--- a/src/code/views/share-dialog-view.coffee
+++ b/src/code/views/share-dialog-view.coffee
@@ -75,11 +75,13 @@ module.exports = React.createClass
     if sharedDocumentId
       documentServer = getQueryParam('documentServer') or 'https://document-store.concord.org'
       documentServer = documentServer.slice(0, -1) while documentServer.substr(-1) is '/'  # remove trailing slash
-      server = encodeURIComponent(@state.codapServerUrl)
+      graphVisToggles = if @state.graphVisToggles then '?app=is' else ''
+      # graphVisToggles is a parameter handled by CODAP, so it needs to be added to its URL.
+      server = encodeURIComponent(@state.codapServerUrl + graphVisToggles)
+      # Other params are handled by document server itself:
       buttonText = if @state.pageType is 'launch' then "&buttonText=#{encodeURIComponent(@state.launchButtonText)}" else ''
       fullscreenScaling = if @state.pageType is 'autolaunch' and @state.fullscreenScaling then '&scaling' else ''
-      graphVisToggles = if @state.graphVisToggles then '&app=is' else ''
-      "#{documentServer}/v2/documents/#{sharedDocumentId}/#{@state.pageType}?server=#{server}#{buttonText}#{fullscreenScaling}#{graphVisToggles}"
+      "#{documentServer}/v2/documents/#{sharedDocumentId}/#{@state.pageType}?server=#{server}#{buttonText}#{fullscreenScaling}"
     else
       null
 


### PR DESCRIPTION
It got broken as I removed `lara` from the state. I'm betting `embed` and `link` could also be removed in the future if they can be calculated at any time (it seems so). Keeping them in the state is redundant.

[#156243160]