### PR TITLE
Fix ability of local storage provider to list directory

### DIFF
--- a/src/code/views/file-dialog-tab-view.coffee
+++ b/src/code/views/file-dialog-tab-view.coffee
@@ -81,12 +81,13 @@ FileDialogTab = React.createClass
   mixins: [AuthorizeMixin]
 
   getInitialState: ->
+    @_isMounted = true
     initialState = @getStateForFolder(@props.client.state.metadata?.parent, true) or null
     initialState.filename = initialState.metadata?.name or ''
     initialState
 
-  componentDidMount: ->
-    @_isMounted = true
+#  componentDidMount: ->
+#    @_isMounted = true
 
   componentWillUnmount: ->
     @_isMounted = false


### PR DESCRIPTION
We were suppressing directory list if dialog not mounted, but this
check failed for localStorage because directory is loaded
synchronously. To fix moved setting of isMounted to init method, since we only care when it gets set to false. 