### PR TITLE
Add `appSetsWindowTitle` configuration parameter to eliminate need for CODAP branch

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -749,7 +749,7 @@ class CloudFileManagerClient
     currentContent
 
   _setWindowTitle: (name) ->
-    if @appOptions?.ui?.windowTitleSuffix
+    if not @appOptions.appSetsWindowTitle and @appOptions?.ui?.windowTitleSuffix
       document.title = "#{if name?.length > 0 then name else (tr "~MENUBAR.UNTITLED_DOCUMENT")}#{@appOptions.ui.windowTitleSeparator}#{@appOptions.ui.windowTitleSuffix}"
 
   _getHashParams: (metadata) ->


### PR DESCRIPTION
The only difference between the CODAP branch and the master branch is that the code for setting the window title is removed in the CODAP branch. By setting the `appSetsWindowTitle` configuration parameter to true, the desired behavior can be achieved without maintaining a separate CODAP branch.