### PR TITLE
Changes for SageModeler LARA embedding [#162759997]

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -636,7 +636,8 @@ class CloudFileManagerClient
       dirty: isDirty
       saved: @state.saved and not isDirty
     if window.self isnt window.top
-      window.top.postMessage({type: "cfm::setDirty", isDirty: isDirty}, "*")
+      # post to parent and not top window (not a bug even though we test for self inst top above)
+      window.parent.postMessage({type: "cfm::setDirty", isDirty: isDirty}, "*")
 
   shouldAutoSave: =>
     @state.dirty and

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -158,7 +158,7 @@ App = React.createClass
       else if @state.importDialog
         (ImportTabbedDialog {client: @props.client, dialog: @state.importDialog, close: @closeDialogs})
       else if @state.shareDialog
-        (ShareDialog {client: @props.client, enableLaraSharing: @props.enableLaraSharing, close: @closeDialogs})
+        (ShareDialog {client: @props.client, enableLaraSharing: @props.enableLaraSharing, close: @closeDialogs, settings: @props.ui?.shareDialog or {}})
 
       # alert and confirm dialogs can be overlayed on other dialogs
       if @state.alertDialog

--- a/src/code/views/share-dialog-view.coffee
+++ b/src/code/views/share-dialog-view.coffee
@@ -46,7 +46,8 @@ module.exports = React.createClass
     link: @getShareLink()
     embed: @getEmbed()
     pageType: "autolaunch"
-    codapServerUrl: "https://codap.concord.org/releases/latest/"
+    serverUrl: @props.settings.serverUrl or "https://codap.concord.org/releases/latest/"
+    serverUrlLabel: @props.settings.serverUrlLabel or translate("~SHARE_DIALOG.LARA_CODAP_URL")
     launchButtonText: "Launch"
     fullscreenScaling: true
     graphVisToggles: false
@@ -80,7 +81,7 @@ module.exports = React.createClass
       documentServer = documentServer.slice(0, -1) while documentServer.substr(-1) is '/'  # remove trailing slash
       graphVisToggles = if @state.graphVisToggles then '?app=is' else ''
       # graphVisToggles is a parameter handled by CODAP, so it needs to be added to its URL.
-      server = encodeURIComponent(@state.codapServerUrl + graphVisToggles)
+      server = encodeURIComponent(@state.serverUrl + graphVisToggles)
       # Other params are handled by document server itself:
       buttonText = if @state.pageType is 'launch' then "&buttonText=#{encodeURIComponent(@state.launchButtonText)}" else ''
       fullscreenScaling = if @state.pageType is 'autolaunch' and @state.fullscreenScaling then '&scaling' else ''
@@ -157,9 +158,9 @@ module.exports = React.createClass
   selectLaraTab: ->
     @setState tabSelected: 'lara'
 
-  changedCodapServerUrl: (event) ->
+  changedServerUrl: (event) ->
     @setState
-      codapServerUrl: event.target.value
+      serverUrl: event.target.value
 
   changedLaunchButtonText: (event) ->
     @setState
@@ -236,9 +237,9 @@ module.exports = React.createClass
                     )
                     (div {className: 'lara-settings'},
                       (div {className: 'codap-server-url'},
-                        translate("~SHARE_DIALOG.LARA_CODAP_URL")
+                        @state.serverUrlLabel
                         (div {},
-                          (input {value: @state.codapServerUrl, onChange: @changedCodapServerUrl})
+                          (input {value: @state.serverUrl, onChange: @changedServerUrl})
                         )
                       )
                       (div {className: 'autolaunch'},


### PR DESCRIPTION
- changed post message to post to parent and not top window so that SageModeler (parent) gets message and not docstore iframe (top)
- added optional UI settings for share dialog server url value and label