### PR TITLE
Fix example loads in CODAP [#162641359]

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -720,7 +720,11 @@ class CloudFileManagerClient
     @_event type, { content: content?.getClientContent(), shared: @_sharedMetadata() }
 
   _fileOpened: (content, metadata, additionalState={}, hashParams=null) ->
-    @_event 'openedFile', { content: content?.getClientContent() }, (iError, iSharedMetadata) =>
+    eventData = { content: content?.getClientContent() }
+    # add metadata contentType to event for CODAP to load via postmessage API (for SageModeler standalone)
+    contentType = metadata.mimeType or metadata.contentType
+    eventData.metadata = {contentType} if contentType
+    @_event 'openedFile', eventData, (iError, iSharedMetadata) =>
       return @alert(iError, => @ready()) if iError
 
       metadata?.overwritable ?= true

--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -244,6 +244,7 @@ class GoogleDriveProvider extends ProviderInterface
         metadata.rename file.title
         metadata.overwritable = file.editable
         metadata.providerData = id: file.id
+        metadata.mimeType = file.mimeType
         if not metadata.parent? and file.parents?.length > 0
           metadata.parent = new CloudMetadata
             type: CloudMetadata.Folder

--- a/src/code/providers/readonly-provider.coffee
+++ b/src/code/providers/readonly-provider.coffee
@@ -132,6 +132,7 @@ class ReadOnlyProvider extends ProviderInterface
           name: item.name
           type: type
           description: item.description
+          mimeType: item.mimeType
           content: if item.content? then cloudContentFactory.createEnvelopedCloudContent item.content else undefined
           url: item.url or item.location
           parent: parent


### PR DESCRIPTION
CODAP expects the openedFile event to contain the url in the event metadata.  This was not present when using the event postmessage api.