### PR TITLE
Change height and width calculations fix Modal Dialogs on Firefox

### DIFF
--- a/src/code/views/modal-view.coffee
+++ b/src/code/views/modal-view.coffee
@@ -10,8 +10,8 @@ module.exports = React.createClass
 
   # shadow the entire viewport behind the dialog
   getDimensions: ->
-    width: $(window).width() + 'px'
-    height: $(window).height() + 'px'
+    width: '100vw'
+    height: '100vh'
 
   getInitialState: ->
     dimensions = @getDimensions()


### PR DESCRIPTION
Addresses issue logged here: https://www.pivotaltracker.com/story/show/161082471 
When used in Sage, the Open menu would appear halfway off the top of the screen on Firefox, this seems to be related to handling of rendering while the html is in Quirks mode, as the height would be calculated to 0 on Firefox. Changing to VW and VH (Viewport Width and Height) seems to work well on Chrome, Safari, and Firefox on Mac using the all-providers.html test page. 

An alternative approach would be to use the DOCTYPE on the html to enforce strict mode instead of quirks mode, but this would have cascade issues elsewhere (see https://developer.mozilla.org/en-US/docs/Mozilla/Mozilla_quirks_mode_behavior)