### PR TITLE
Added scropes option to google-drive-provider

### DIFF
--- a/src/code/providers/google-drive-provider.coffee
+++ b/src/code/providers/google-drive-provider.coffee
@@ -69,6 +69,12 @@ class GoogleDriveProvider extends ProviderInterface
     @clientId = @options.clientId
     if not @clientId
       throw new Error (tr "~GOOGLE_DRIVE.ERROR_MISSING_CLIENTID")
+    @scopes = @options.scopes or [
+      'https://www.googleapis.com/auth/drive'
+      'https://www.googleapis.com/auth/drive.install'
+      'https://www.googleapis.com/auth/drive.file'
+      'https://www.googleapis.com/auth/userinfo.profile'
+    ]
     @mimeType = @options.mimeType or "text/plain"
     @readableMimetypes = @options.readableMimetypes
     @useRealTimeAPI = @options.useRealTimeAPI or false
@@ -96,12 +102,7 @@ class GoogleDriveProvider extends ProviderInterface
     @_loadedGAPI =>
       args =
         client_id: @clientId
-        scope: [
-          'https://www.googleapis.com/auth/drive'
-          'https://www.googleapis.com/auth/drive.install'
-          'https://www.googleapis.com/auth/drive.file'
-          'https://www.googleapis.com/auth/userinfo.profile'
-        ]
+        scope: @scopes
         immediate: immediate
       gapi.auth.authorize args, (authToken) =>
         @authToken = if authToken and not authToken.error then authToken else null


### PR DESCRIPTION
This allows sage-modeler-site to specify a resticted list of scopes.