### PR TITLE
URL Parameters Processed Twice

### DIFF
--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -52,7 +52,7 @@ class CloudFileManager
     @client.processUrlParams()
 
     # if iframed let the parent know about the connect
-    if window.parent
+    if window.parent isnt window
       window.parent.postMessage({type: "cfm::iframedClientConnected"}, "*")
 
   _createHiddenApp: ->


### PR DESCRIPTION
app.clientConnect has an incorrect test whether it is in the root browser window.
This always fails and results in CFM sending postMessage to itself.