### PR TITLE
Fix extension not being added when filename as dot in it [#168903516]

### DIFF
--- a/src/code/providers/provider-interface.coffee
+++ b/src/code/providers/provider-interface.coffee
@@ -51,8 +51,15 @@ class CloudMetadata
     @filename = @name
     if @name?.substr? and CloudMetadata.Extension? and @type is CloudMetadata.File
       extLen = CloudMetadata.Extension.length
-      @name = @name.substr(0, @name.length - (extLen+1)) if @name.substr(-extLen+1) is ".#{CloudMetadata.Extension}"
-      @filename = CloudMetadata.withExtension @name, null, true
+      if extLen > 0
+        # at this point the filename and name are the same so we now check for a file extension
+        hasCurrentExtension = @name.substr(-extLen-1) is ".#{CloudMetadata.Extension}"
+        if hasCurrentExtension
+          # remove extension from name for display purposes
+          @name = @name.substr(0, @name.length - (extLen+1))
+        else
+          # add extension to filename for saving purposes
+          @filename += "." + CloudMetadata.Extension
 
 # singleton that can create CloudContent wrapped with global options
 class CloudContentFactory


### PR DESCRIPTION
Fixes two bugs:

1. The check for the existing extension was comparing the substring at the end of the name of length extensionLength -1 to the concatenaton of a dot and the extension instead of the substring of extensionLength + 1 (the +1 to add the dot being compared).

2. When the extension was added any existing extension was being dropped with no check to see if the extensions matched.

This change also tries to unpack the dense update code with comments and a conditional path.