### PR TITLE
Use _event to broadcast log events to listeners

### DIFF
--- a/src/code/client.coffee
+++ b/src/code/client.coffee
@@ -199,6 +199,7 @@ class CloudFileManagerClient
       @_listeners.push listener
 
   log: (event, eventData) ->
+    @_event 'log', {logEvent: event, logEventData: eventData}
     if (@appOptions.log)
       @appOptions.log event, eventData
 


### PR DESCRIPTION
This will be used to ensure that the `run_remote_endpoint` is set in CODAP when we are wrapped in SageModeler.

CODAP handles `logLaraData` in its version of the LARA provider, and uses it to set the `run_remote_endpoint` using the data LARA passes in.

SageModeler, however, defines a LARA provider but does not handle `logLaraData`. So the only version of `logLaraData` that gets called is the CFM's own client version.

This updates the client code to rebroadcast the message using `_event`. We will then update CODAP to handle this message and set the `run_remote_endpoint` accordingly.

https://www.pivotaltracker.com/story/show/172071393