### PR TITLE
Resolve issues with loading legacy documents

### DIFF
--- a/src/code/client.js
+++ b/src/code/client.js
@@ -771,7 +771,11 @@ class CloudFileManagerClient {
   }
 
   revertToShared(callback = null) {
-    const id = this.state.currentContent != null ? this.state.currentContent.get("sharedDocumentId") : undefined
+    // Look for sharedDocumentUrl or Url first:
+    const id = this.state.currentContent?.get("sharedDocumentUrl")
+            || this.state.currentContent?.get("url")
+            || this.state.currentContent?.get("sharedDocumentId")
+
     if (id && (this.state.shareProvider != null)) {
       return this.state.shareProvider.loadSharedContent(id, (err, content, metadata) => {
         let docName

--- a/src/code/providers/s3-provider.test.ts
+++ b/src/code/providers/s3-provider.test.ts
@@ -1,0 +1,37 @@
+
+import { ImportMock } from 'ts-mock-imports'
+import S3Provider from "./s3-provider"
+import * as Client from "../client"
+import { CloudMetadata } from "./provider-interface"
+
+const clientMockManager = ImportMock.mockClass(Client, 'CloudFileManagerClient')
+const client = clientMockManager.getMockInstance()
+
+
+describe("S3ShareProvider", () => {
+  const provider = new S3Provider(client)
+  describe("load(metadata: CloudMetadata, callback: callbackSigLoad)", () => {
+    describe("when using a legacy documentID", () => {
+      it('should return a legacy url', () => {
+        const contentId = "1234"
+        const metadata = new CloudMetadata({filename: "test", sharedContentId: contentId})
+        const callback = (err:string, content: any) => true
+        provider.loadFromUrl = (string) => { expect(string).toMatch("legacy-document-store/1234") }
+        provider.load(metadata, callback)
+      })
+    })
+
+    describe("when the ID is a full URL", () => {
+      it('should return the url', () => {
+        const urlToContent = "https://somethingcool/1234sdfsf/foo.txt"
+        const metadata = new CloudMetadata({filename: "test", sharedContentId: urlToContent})
+        const callback = (err:string, content: any) => true
+        provider.loadFromUrl = (string) => { expect(string).toBe(urlToContent) }
+        provider.load(metadata, callback)
+      })
+    })
+
+  })
+})
+
+

--- a/src/code/providers/s3-provider.ts
+++ b/src/code/providers/s3-provider.ts
@@ -68,7 +68,7 @@ class S3Provider extends ProviderInterface {
     });
   }
 
-  private loadFromUrl(
+  loadFromUrl(
     documentUrl: string,
     metadata: CloudMetadata,
     callback: callbackSigLoad) {

--- a/src/code/providers/s3-share-provider.test.ts
+++ b/src/code/providers/s3-share-provider.test.ts
@@ -1,7 +1,7 @@
 
 import { ImportMock } from 'ts-mock-imports'
 import S3ShareProvider from "./s3-share-provider"
-import * as helperModule from './s3-share-provider-token-service-helper'
+import * as helperModule from '../utils/s3-share-provider-token-service-helper'
 import * as Client from "../client"
 import { CloudContent, CloudMetadata, ICloudMetaDataSpec } from "./provider-interface"
 import LocalStorageProvider from './localstorage-provider'

--- a/src/code/providers/s3-share-provider.test.ts
+++ b/src/code/providers/s3-share-provider.test.ts
@@ -3,7 +3,7 @@ import { ImportMock } from 'ts-mock-imports'
 import S3ShareProvider from "./s3-share-provider"
 import * as helperModule from '../utils/s3-share-provider-token-service-helper'
 import * as Client from "../client"
-import { CloudContent, CloudMetadata, ICloudMetaDataSpec } from "./provider-interface"
+import { CloudContent, CloudMetadata } from "./provider-interface"
 import LocalStorageProvider from './localstorage-provider'
 
 const clientMockManager = ImportMock.mockClass(Client, 'CloudFileManagerClient')

--- a/src/code/utils/config.ts
+++ b/src/code/utils/config.ts
@@ -1,7 +1,7 @@
 
 export type EnvironmentNameType = "dev" | "staging" | "production"
 
-export const TOKEN_SERVICE_ENV = (process.env["TOKEN_SERVICE_ENV"] || "staging") as EnvironmentNameType
+export const getTokenServiceEnv = () =>  (process.env["TOKEN_SERVICE_ENV"] || "staging") as EnvironmentNameType
 export const PORTAL_AUTH_PATH = "/auth/oauth_authorize"
 export const DEFAULT_MAX_AGE_SECONDS = 60
 export const TOKEN_SERVICE_TOOL_NAME = "cfm-shared"

--- a/src/code/utils/config.ts
+++ b/src/code/utils/config.ts
@@ -1,0 +1,10 @@
+
+export type EnvironmentNameType = "dev" | "staging" | "production"
+
+export const TOKEN_SERVICE_ENV = (process.env["TOKEN_SERVICE_ENV"] || "staging") as EnvironmentNameType
+export const PORTAL_AUTH_PATH = "/auth/oauth_authorize"
+export const DEFAULT_MAX_AGE_SECONDS = 60
+export const TOKEN_SERVICE_TOOL_NAME = "cfm-shared"
+export const TOKEN_SERVICE_TOOL_TYPE = "s3Folder"
+export const S3_SHARED_DOC_PATH_LEGACY = "legacy-document-store"
+export const S3_SHARED_DOC_PATH_NEW = "cfm-shared-documents"

--- a/src/code/utils/s3-share-provider-token-service-helper.test.ts
+++ b/src/code/utils/s3-share-provider-token-service-helper.test.ts
@@ -1,0 +1,66 @@
+import { ImportMock } from 'ts-mock-imports'
+import {getLegacyUrl, getModernUrl} from './s3-share-provider-token-service-helper'
+import * as Config from "./config"
+
+// export const getModernUrl = (documentId: string, filename:string) => {
+//   const path = S3_SHARED_DOC_PATH_NEW
+//   return `${getBaseDocumentUrl()}/${path}/${documentId}/${filename}`
+// }
+
+// export const getLegacyUrl = (documentId: string) => {
+//   const path = S3_SHARED_DOC_PATH_LEGACY
+//   return `${getBaseDocumentUrl()}/${path}/${documentId}`
+// };
+
+const filename = "testing.txt"
+const newId = "2a334ddse2"
+const legacyId = "23424"
+
+describe("s3-share-provider-token-service-helper", () => {
+  describe("production environment", () => {
+    beforeEach( () => {
+      ImportMock.mockFunction(Config, 'getTokenServiceEnv', 'production')
+    })
+    afterEach( () => {
+      ImportMock.restore();
+    })
+    describe("getModernUrl", () => {
+      it("return a modern production S3 URL for a document id", () => {
+  
+        const result = getModernUrl(newId, filename)
+        expect(result).toEqual("https://models-resources.concord.org/cfm-shared-documents/2a334ddse2/testing.txt")
+      })
+    })
+    describe("getLegacyUrl", () => {
+      it("should return a production legacy url … ", () => {
+        const result = getLegacyUrl(legacyId)
+        expect(result).toEqual("https://models-resources.concord.org/legacy-document-store/23424")
+      })
+    })
+  })
+  describe("staging environment", () => {
+    beforeEach( () => {
+      ImportMock.mockFunction(Config, 'getTokenServiceEnv', 'staging')
+    })
+    afterEach( () => {
+      ImportMock.restore();
+    })
+    describe("getModernUrl", () => {
+      it("return a modern S3 URL for a document id", () => {
+  
+        const result = getModernUrl(newId, filename)
+        expect(result).toEqual("https://token-service-files.concordqa.org/cfm-shared-documents/2a334ddse2/testing.txt")
+      })
+    })
+    describe("getLegacyUrl", () => {
+      it("should return a legacy url … ", () => {
+        const result = getLegacyUrl(legacyId)
+        expect(result).toEqual("https://token-service-files.concordqa.org/legacy-document-store/23424")
+      })
+    })
+  })
+})
+
+
+
+

--- a/src/code/utils/s3-share-provider-token-service-helper.ts
+++ b/src/code/utils/s3-share-provider-token-service-helper.ts
@@ -4,7 +4,7 @@ import * as AWS from "aws-sdk";
 import {
   PORTAL_AUTH_PATH,
   DEFAULT_MAX_AGE_SECONDS,
-  TOKEN_SERVICE_ENV,
+  getTokenServiceEnv,
   TOKEN_SERVICE_TOOL_NAME,
   TOKEN_SERVICE_TOOL_TYPE,
   S3_SHARED_DOC_PATH_LEGACY,
@@ -57,7 +57,9 @@ export const createFile = async ({ filename, fileContent, firebaseJwt, maxAge=DE
   // - getCredentials call. If user is not authenticated, readWriteToken needs to be provided instead.
   const anonymous = !firebaseJwt;
 
-  const client = anonymous ? new TokenServiceClient({ env: TOKEN_SERVICE_ENV }) : new TokenServiceClient({ env: TOKEN_SERVICE_ENV, jwt: firebaseJwt })
+  const client = anonymous
+    ? new TokenServiceClient({ env: getTokenServiceEnv() })
+    : new TokenServiceClient({ env: getTokenServiceEnv(), jwt: firebaseJwt })
   const resource: S3Resource = await client.createResource({
     tool: TOKEN_SERVICE_TOOL_NAME,
     type: TOKEN_SERVICE_TOOL_TYPE,
@@ -117,8 +119,8 @@ export const updateFile = async ({
   const anonymous = !firebaseJwt && readWriteToken;
 
   const client = anonymous
-    ? new TokenServiceClient({ env: TOKEN_SERVICE_ENV })
-    : new TokenServiceClient({ env: TOKEN_SERVICE_ENV, jwt: firebaseJwt })
+    ? new TokenServiceClient({ env: getTokenServiceEnv() })
+    : new TokenServiceClient({ env: getTokenServiceEnv(), jwt: firebaseJwt })
 
   const resource: S3Resource = await client.getResource(resourceId) as S3Resource;
   const credentials = anonymous
@@ -150,7 +152,7 @@ export const updateFile = async ({
 const getBaseDocumentUrl = () => {
   const stagingBase = "https://token-service-files.concordqa.org"
   const productionBase = "https://models-resources.concord.org"
-  const base = TOKEN_SERVICE_ENV === "production"
+  const base = getTokenServiceEnv() === "production"
     ? productionBase
     : stagingBase
   return base
@@ -168,7 +170,7 @@ export const getLegacyUrl = (documentId: string) => {
 
 // When would we do this?
 export const getAllResources = async (firebaseJwt: string, amOwner: boolean) => {
-  const client = new TokenServiceClient({ jwt: firebaseJwt, env: TOKEN_SERVICE_ENV });
+  const client = new TokenServiceClient({ jwt: firebaseJwt, env: getTokenServiceEnv() });
   const resources = await client.listResources({
     type: "s3Folder",
     tool: TOKEN_SERVICE_TOOL_NAME,

--- a/src/code/views/share-dialog-view.js
+++ b/src/code/views/share-dialog-view.js
@@ -20,7 +20,7 @@ import getQueryParam  from '../utils/get-query-param'
 // of the react function, "tr".
 import translate  from '../utils/translate'
 import socialIcons  from 'svg-social-icons/lib/icons.json'
-import { getLegacyUrl } from '../providers/s3-share-provider-token-service-helper'
+import { getLegacyUrl } from '../utils/s3-share-provider-token-service-helper'
 const SocialIcon = createReactClassFactory({
 
   displayName: 'SocialIcon',


### PR DESCRIPTION

* Loads legacy docstore documents
* fixes 🐞 Revert to shared view doesn't work
* Configure strings using `utils/config.ts`
* Move `s3-share-provider-token-service-helper.ts` to `utils/` directory
* Adds a few more tests around shared loading

[#172324177]
https://www.pivotaltracker.com/story/show/172324177