### PR TITLE
[CODAP-sync] Enable CSV import by URL parameter

### DIFF
--- a/src/code/client.js
+++ b/src/code/client.js
@@ -1076,7 +1076,7 @@ class CloudFileManagerClient {
     this._updateState(content, metadata, additionalState, hashParams)
     // add metadata contentType to event for CODAP to load via postmessage API (for SageModeler standalone)
     const contentType = metadata.mimeType || metadata.contentType
-    if (contentType) { eventData.metadata = {contentType} }
+    eventData.metadata = {contentType, url: metadata.url, filename: metadata.filename}
     return this._event('openedFile', eventData, (iError, iSharedMetadata) => {
       if (iError) { return this.alert(iError, () => this.ready()) }
 

--- a/src/code/providers/url-provider.js
+++ b/src/code/providers/url-provider.js
@@ -44,7 +44,6 @@ class URLProvider extends ProviderInterface {
     })
 
     return $.ajax({
-      dataType: 'json',
       url: metadata.url,
       success(data) {
         return callback(null, cloudContentFactory.createEnvelopedCloudContent(data), metadata)


### PR DESCRIPTION
The goal of this and the other PRs tagged with `[CODAP-sync]` is to attempt to eliminate the differences between the CODAP and master branches. Each PR represents a set of changes that were made on the CODAP branch that seem as though they should be sufficiently general that they can be merged to master and made accessible to all clients. Thus, review should consist of two components:

1. From the CODAP perspective, do the proposed code changes accurately reflect the prior behavior of the CODAP branch?
2. From the non-CODAP perspective, do the proposed code changes make sense as the default behavior for non-CODAP clients as well as for CODAP clients? @ddamelin 

Contains the contents of two commits which reference two PT stories.

---
[[#162736733]](https://www.pivotaltracker.com/story/show/162736733) Make it possible to launch CODAP with a CSV via URL parameter
* Remove JSON type in ajax request for URL Provider

[38129daf](https://github.com/concord-consortium/cloud-file-manager/commit/38129daf12e4ebfb8d6e603dce72a4b7d032099b) Cherry-picked from CODAP branch

---
[[#166523992]](https://www.pivotaltracker.com/story/show/166523992) Fix bug: Cannot open csv from URL param.

[efeb6a69](https://github.com/concord-consortium/cloud-file-manager/commit/efeb6a698a262c562d29914ddf26a10d29eac5c7) Cherry-picked from CODAP branch

