### PR TITLE
[CODAP-sync] Check language of page before language of browser

### DIFF
--- a/src/code/utils/translate.js
+++ b/src/code/utils/translate.js
@@ -37,6 +37,14 @@ const getBaseLanguage = function(langKey) {
   return undefined
 }
 
+// use language of page, which is used by CODAP, with separate build for each language
+const getPageLanguage = function() {
+  const pageLang = document.documentElement.lang
+  return pageLang && (pageLang !== "unknown")
+          ? pageLang
+          : undefined
+}
+
 const getFirstBrowserLanguage = function() {
   const nav = window.navigator
   const languages = nav ? (nav.languages || []).concat([nav.language, nav.browserLanguage, nav.systemLanguage, nav.userLanguage]) : []
@@ -54,7 +62,7 @@ languageFiles.forEach(function(lang) {
   if (baseLang) { return translations[baseLang] = lang.contents }
 })
 
-const lang = urlParams.lang || getFirstBrowserLanguage()
+const lang = urlParams.lang || getPageLanguage() || getFirstBrowserLanguage()
 const baseLang = getBaseLanguage(lang || '')
 const defaultLang = lang && translations[lang] ? lang : baseLang && translations[baseLang] ? baseLang : "en"
 


### PR DESCRIPTION
The goal of this and the other PRs tagged with `[CODAP-sync]` is to attempt to eliminate the differences between the CODAP and master branches. Each PR represents a set of changes that were made on the CODAP branch that seem as though they should be sufficiently general that they can be merged to master and made accessible to all clients. Thus, review should consist of two components:

1. From the CODAP perspective, do the proposed code changes accurately reflect the prior behavior of the CODAP branch?
2. From the non-CODAP perspective, do the proposed code changes make sense as the default behavior for non-CODAP clients as well as for CODAP clients? @ddamelin 

---
[[#172561086]](https://www.pivotaltracker.com/story/show/172561086) Check language of page before language of browser

[b635a9fa](https://github.com/concord-consortium/cloud-file-manager/commit/b635a9faaf50c290e08434bac856efdb4b396dba) Cherry-picked from CODAP branch