### PR TITLE
Don't require openSavedParams when canOpenSaved is false

### DIFF
--- a/src/code/client.js
+++ b/src/code/client.js
@@ -1197,8 +1197,8 @@ class CloudFileManagerClient {
   }
 
   _getHashParams(metadata) {
-    let openSavedParams = metadata?.provider?.getOpenSavedParams(metadata)
     const canOpenSaved = metadata?.provider?.canOpenSaved() || false
+    let openSavedParams = canOpenSaved ? metadata?.provider?.getOpenSavedParams(metadata) : null
     if (canOpenSaved && (openSavedParams != null)) {
       return `#file=${metadata.provider.urlDisplayName || metadata.provider.name}:${encodeURIComponent(openSavedParams)}`
     } else if ((metadata != null ? metadata.provider : undefined) instanceof URLProvider &&


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173733992

local-file-provider returns `false` from `canOpenSaved`. But it was showing an error during saving as `getOpenSavedParams` was not implemented there. In fact, it doesn't make sense to call `getOpenSavedParams` when `canOpenSaved` returns false, as these params won't be used anyway. 