### PR TITLE
Fix sharing of documents without filename set

### DIFF
--- a/src/code/client.js
+++ b/src/code/client.js
@@ -769,6 +769,15 @@ class CloudFileManagerClient {
   }
 
   share(callback) {
+    if (!this.state.metadata) {
+      // PJ, 07/10/2020: Without these lines the sharing process will fail (it looks for filename and later tries to
+      // update metadata object). Apparently, there's an assumption that metadata already exists. It can initialized
+      // in a few random places, but a new document that has never been renamed won't have this object available.
+      this.state.metadata = new CloudMetadata({
+        name: tr("~MENUBAR.UNTITLED_DOCUMENT"),
+        type: CloudMetadata.File
+      })
+    }
     return this.setShareState(true, (err, sharedContentId, currentContent) => {
       this._fileChanged('sharedFile', currentContent, this.state.metadata)
       return (typeof callback === 'function' ? callback(null, sharedContentId) : undefined)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173733790

The sharing process was:
- assuming that metadata exists and trying to get filename from it
- trying to update `this.state.metadata` after sharing is complete

Comment should explain the fix. I don't really understand where CloudMetadata should be created. It was tempting to create it even in the constructor. But since there are many places where it's created later or the code checks if it's available, it seemed risky before our big CFM update.