### PR TITLE
Use production token-service, cleanup related files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@concord-consortium/token-service": "^1.3.0",
     "aws-sdk": "^2.668.0",
     "base64-js": "^1.2.0",
-    "client-oauth2": "^4.2.5",
     "create-react-class": "^15.6.3",
     "diff": "^2.2.1",
     "es6-promise": "^3.1.2",

--- a/src/code/providers/s3-provider.ts
+++ b/src/code/providers/s3-provider.ts
@@ -1,8 +1,5 @@
-
-
 import {
   ICloudMetaDataSpec,
-  callbackSigShare,
   callbackSigLoad,
   callbackSigSave,
   ProviderInterface,

--- a/src/code/providers/s3-share-provider.ts
+++ b/src/code/providers/s3-share-provider.ts
@@ -1,5 +1,3 @@
-
-
 import {
   ICloudMetaDataSpec,
   callbackSigShare,
@@ -15,8 +13,6 @@ import { createFile, updateFile } from '../utils/s3-share-provider-token-service
 import { reportError } from '../utils/report-error'
 
 interface IClientInterface {}
-
-
 
 // New method for sharing read only documents using S3.
 // The readWrite key must be retained in the original document

--- a/src/code/utils/config.ts
+++ b/src/code/utils/config.ts
@@ -1,10 +1,7 @@
-
 export type EnvironmentNameType = "dev" | "staging" | "production"
 
-export const getTokenServiceEnv = () =>  (process.env["TOKEN_SERVICE_ENV"] || "staging") as EnvironmentNameType
-export const PORTAL_AUTH_PATH = "/auth/oauth_authorize"
+export const getTokenServiceEnv = () =>  (process.env["TOKEN_SERVICE_ENV"] || "production") as EnvironmentNameType
 export const DEFAULT_MAX_AGE_SECONDS = 60
 export const TOKEN_SERVICE_TOOL_NAME = "cfm-shared"
 export const TOKEN_SERVICE_TOOL_TYPE = "s3Folder"
 export const S3_SHARED_DOC_PATH_LEGACY = "legacy-document-store"
-export const S3_SHARED_DOC_PATH_NEW = "cfm-shared-documents"

--- a/src/code/utils/s3-share-provider-token-service-helper.test.ts
+++ b/src/code/utils/s3-share-provider-token-service-helper.test.ts
@@ -1,19 +1,7 @@
 import { ImportMock } from 'ts-mock-imports'
-import {getLegacyUrl, getModernUrl} from './s3-share-provider-token-service-helper'
+import { getLegacyUrl } from './s3-share-provider-token-service-helper'
 import * as Config from "./config"
 
-// export const getModernUrl = (documentId: string, filename:string) => {
-//   const path = S3_SHARED_DOC_PATH_NEW
-//   return `${getBaseDocumentUrl()}/${path}/${documentId}/${filename}`
-// }
-
-// export const getLegacyUrl = (documentId: string) => {
-//   const path = S3_SHARED_DOC_PATH_LEGACY
-//   return `${getBaseDocumentUrl()}/${path}/${documentId}`
-// };
-
-const filename = "testing.txt"
-const newId = "2a334ddse2"
 const legacyId = "23424"
 
 describe("s3-share-provider-token-service-helper", () => {
@@ -23,13 +11,6 @@ describe("s3-share-provider-token-service-helper", () => {
     })
     afterEach( () => {
       ImportMock.restore();
-    })
-    describe("getModernUrl", () => {
-      it("return a modern production S3 URL for a document id", () => {
-  
-        const result = getModernUrl(newId, filename)
-        expect(result).toEqual("https://models-resources.concord.org/cfm-shared-documents/2a334ddse2/testing.txt")
-      })
     })
     describe("getLegacyUrl", () => {
       it("should return a production legacy url … ", () => {
@@ -44,13 +25,6 @@ describe("s3-share-provider-token-service-helper", () => {
     })
     afterEach( () => {
       ImportMock.restore();
-    })
-    describe("getModernUrl", () => {
-      it("return a modern S3 URL for a document id", () => {
-  
-        const result = getModernUrl(newId, filename)
-        expect(result).toEqual("https://token-service-files.concordqa.org/cfm-shared-documents/2a334ddse2/testing.txt")
-      })
     })
     describe("getLegacyUrl", () => {
       it("should return a legacy url … ", () => {


### PR DESCRIPTION
[#173754567]

This PR changes default token-service env to "production" and removes some utilities/helpers/config that were not necessary.