### PR TITLE
Remove CFMOrigin from LARA share dialog

### DIFF
--- a/src/code/utils/lang/de.json
+++ b/src/code/utils/lang/de.json
@@ -116,9 +116,7 @@
     "~SHARE_DIALOG.EMBED_MESSAGE": "Code einbetten für Webseiten oder andere Inhalte",
     "~SHARE_DIALOG.LARA_MESSAGE": "Diesen Link verwenden, um eine Aktivität in LARA zu erstellen",
     "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
-    "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Autolaunch Seite",
     "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Vollbild und Skalieren",
-    "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Textbutton",
     "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Datensichtbarkeit in Graphen anzeigen",
     "~CONFIRM.CHANGE_LANGUAGE": "Einige Änderungen wurden nicht gespeichert. Sind Sie sicher, dass Sie die Sprache wechseln wollen?",
     "~FILE_STATUS.FAILURE": "Retrying..."

--- a/src/code/utils/lang/el.json
+++ b/src/code/utils/lang/el.json
@@ -116,9 +116,7 @@
     "~SHARE_DIALOG.EMBED_MESSAGE": "Κώδικας για ενσωμάτωση σε ιστοσελίδες ή άλλο δικτυακό περιεχόμενο",
     "~SHARE_DIALOG.LARA_MESSAGE": "Χρησιμοποιήστε αυτό το σύνδεσμο όταν δημιουργείτε μια δραστηριότητα στο LARA",
     "~SHARE_DIALOG.LARA_CODAP_URL": "URL του διακομιστή CODAP:",
-    "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Σελίδα αυτόματης εκτέλεσης",
     "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Πλήκτρο πλήρους οθόνης και κλιμάκωση",
-    "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Κείμενο Πλήκτρου Εκτέλεσης",
     "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Η προβολή δεδομένων ενεργοποιεί τα γραφήματα",
     "~CONFIRM.CHANGE_LANGUAGE": "Έχετε μη αποθηκευμένες αλλαγές. Είστε σίγουροι ότι θέλετε να αλλάξετε γλώσσα;",
     "~FILE_STATUS.FAILURE": "Retrying..."

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -81,9 +81,7 @@
   "~SHARE_DIALOG.EMBED_MESSAGE": "Embed code for including in webpages or other web-based content",
   "~SHARE_DIALOG.LARA_MESSAGE": "Use this link when creating an activity in LARA",
   "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
-  "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Autolaunch page",
   "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",
-  "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Launch Button Text:",
   "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Display data visibility toggles on graphs",
   "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
 

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -81,7 +81,6 @@
   "~SHARE_DIALOG.EMBED_MESSAGE": "Embed code for including in webpages or other web-based content",
   "~SHARE_DIALOG.LARA_MESSAGE": "Use this link when creating an activity in LARA",
   "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
-  "~SHARE_DIALOG.CFM_ORIGIN_URL": "CFM Origin:",
   "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Autolaunch page",
   "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",
   "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Launch Button Text:",

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -81,9 +81,7 @@
   "~SHARE_DIALOG.EMBED_MESSAGE": "Embed code for including in webpages or other web-based content",
   "~SHARE_DIALOG.LARA_MESSAGE": "Use this link when creating an activity in LARA",
   "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
-  "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Autolaunch page",
   "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",
-  "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Launch Button Text:",
   "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Display data visibility toggles on graphs",
   "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
 

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -81,7 +81,6 @@
   "~SHARE_DIALOG.EMBED_MESSAGE": "Embed code for including in webpages or other web-based content",
   "~SHARE_DIALOG.LARA_MESSAGE": "Use this link when creating an activity in LARA",
   "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
-  "~SHARE_DIALOG.CFM_ORIGIN_URL": "CFM Origin:",
   "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Autolaunch page",
   "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",
   "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Launch Button Text:",

--- a/src/code/utils/lang/es.json
+++ b/src/code/utils/lang/es.json
@@ -116,9 +116,7 @@
     "~SHARE_DIALOG.EMBED_MESSAGE": "Embed code for including in webpages or other web-based content",
     "~SHARE_DIALOG.LARA_MESSAGE": "Use this link when creating an activity in LARA",
     "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
-    "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Autolaunch page",
     "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",
-    "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Launch Button Text:",
     "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Display data visibility toggles on graphs",
     "~CONFIRM.CHANGE_LANGUAGE": "You have unsaved changes. Are you sure you want to change languages?",
     "~FILE_STATUS.FAILURE": "Retrying..."

--- a/src/code/utils/lang/he.json
+++ b/src/code/utils/lang/he.json
@@ -116,9 +116,7 @@
     "~SHARE_DIALOG.EMBED_MESSAGE": "שילוב הקוד להוספה בעמודי רשת או תוכן רשתי אחר",
     "~SHARE_DIALOG.LARA_MESSAGE": "השתמשו בקישור זה בעת יצירת פעילות LARA",
     "~SHARE_DIALOG.LARA_CODAP_URL": "URL של שרת CODAP:",
-    "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "הפעלה אוטומטית של הדף",
     "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "כפתור מסך מלא ומירכוז",
-    "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "הפעלת כפתור טקסט:",
     "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "הצגת מידע ויזואלי בגרפים",
     "~CONFIRM.CHANGE_LANGUAGE": "יש לכם שינויים לא שמורים. אתם בטוחים שתרצו להחליף שפה?",
     "~FILE_STATUS.FAILURE": "Retrying..."

--- a/src/code/utils/lang/nb.json
+++ b/src/code/utils/lang/nb.json
@@ -116,9 +116,7 @@
     "~SHARE_DIALOG.EMBED_MESSAGE": "Embedkode for å sette inn på nettsteder eller annet nett-basert innhold",
     "~SHARE_DIALOG.LARA_MESSAGE": "Bruk denne lenken når du lager en oppgave i LARA",
     "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP-server URL",
-    "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Last side automatisk",
     "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullskjermknapp og skalering",
-    "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Tekst på \"Last\"-knapp:",
     "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Vis knapp for synlighet av data i grafer",
     "~CONFIRM.CHANGE_LANGUAGE": "Du har endringer som ikke er lagret. Er du sikker på at du vil endre språk?",
     "~FILE_STATUS.FAILURE": "Retrying..."

--- a/src/code/utils/lang/nn.json
+++ b/src/code/utils/lang/nn.json
@@ -116,9 +116,7 @@
     "~SHARE_DIALOG.EMBED_MESSAGE": "Bygg-inn-kode for å setja inn på nettsider eller anna nettbasert innhald.",
     "~SHARE_DIALOG.LARA_MESSAGE": "Bruk denne linken når du lager ein aktivitet i LARA",
     "~SHARE_DIALOG.LARA_CODAP_URL": "URL til CODAP-serveren:",
-    "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Last side automatisk",
     "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullskjerm-knapp og skalering",
-    "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Tekst på \"Last\"-knapp:",
     "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Vis knapp for synlegheit av data i grafar",
     "~CONFIRM.CHANGE_LANGUAGE": "Du har endringer som ikkje er lagra. Er du sikker på at vil byte språk?",
     "~FILE_STATUS.FAILURE": "Retrying..."

--- a/src/code/utils/lang/tr.json
+++ b/src/code/utils/lang/tr.json
@@ -116,9 +116,7 @@
     "~SHARE_DIALOG.EMBED_MESSAGE": "Embed code for including in webpages or other web-based content",
     "~SHARE_DIALOG.LARA_MESSAGE": "Use this link when creating an activity in LARA",
     "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
-    "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Autolaunch page",
     "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",
-    "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Launch Button Text:",
     "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Display data visibility toggles on graphs",
     "~CONFIRM.CHANGE_LANGUAGE": "You have unsaved changes. Are you sure you want to change languages?",
     "~FILE_STATUS.FAILURE": "Retrying..."

--- a/src/code/utils/lang/zh-TW.json
+++ b/src/code/utils/lang/zh-TW.json
@@ -116,9 +116,7 @@
     "~SHARE_DIALOG.EMBED_MESSAGE": "Embed code for including in webpages or other web-based content",
     "~SHARE_DIALOG.LARA_MESSAGE": "Use this link when creating an activity in LARA",
     "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
-    "~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE": "Autolaunch page",
     "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",
-    "~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT": "Launch Button Text:",
     "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Display data visibility toggles on graphs",
     "~CONFIRM.CHANGE_LANGUAGE": "You have unsaved changes. Are you sure you want to change languages?",
     "~FILE_STATUS.FAILURE": "Retrying..."

--- a/src/code/views/share-dialog-view.js
+++ b/src/code/views/share-dialog-view.js
@@ -53,6 +53,8 @@ const SocialIcon = createReactClassFactory({
   }
 })
 
+const CFM_PRODUCTION = "https://cloud-file-manager.concord.org"
+
 export default createReactClass({
 
   displayName: 'ShareDialogView',
@@ -64,10 +66,6 @@ export default createReactClass({
       pageType: "autolaunch",
       serverUrl: this.props.settings.serverUrl || "https://codap.concord.org/releases/latest/",
       serverUrlLabel: this.props.settings.serverUrlLabel || translate("~SHARE_DIALOG.LARA_CODAP_URL"),
-
-      CFMOrigin: this.props.settings.CFMOrigin || "https://cloud-file-manager.concord.org",
-      CFMOriginLabel: this.props.settings.serverUrlLabel || translate("~SHARE_DIALOG.CFM_ORIGIN_URL"),
-
       launchButtonText: "Launch",
       fullscreenScaling: true,
       graphVisToggles: false,
@@ -143,22 +141,18 @@ export default createReactClass({
     //  1: Get the resource URL (S3 shared document public URL)
     //  2: Get the URL for the autoLauch page (hosted here ...)
     //  3: Construct a URL to <AutlaunchPage
-    const CFMOrigin = this.state.CFMOrigin
-    const autoLaunchpage = `${CFMOrigin}/autolaunch/autolaunch.html`
-    const localCFMBaseUrl = `${CFMOrigin}/js`
-    const encodedCFMBase = encodeURIComponent(localCFMBaseUrl)
-
+    const autoLaunchpage = `${CFM_PRODUCTION}/autolaunch/autolaunch.html`
     const documentServer = encodeURIComponent(this.getShareLink())
-    const graphVisToggles = this.state.graphVisToggles ? '&app=is' : ''
+    const graphVisToggles = this.state.graphVisToggles ? '?app=is' : ''
     // graphVisToggles is a parameter handled by CODAP, so it needs to be added to its URL.
-    const server = encodeURIComponent(`${this.state.serverUrl}?cfmBaseUrl=${encodedCFMBase}${graphVisToggles}`)
+    const server = encodeURIComponent(`${this.state.serverUrl}${graphVisToggles}`)
     // Other params are handled by document server itself:
     const buttonText = this.state.pageType === 'launch' ? `&buttonText=${encodeURIComponent(this.state.launchButtonText)}` : ''
     const fullscreenScaling = (this.state.pageType === 'autolaunch') && this.state.fullscreenScaling ? '&scaling' : ''
 
     return `${autoLaunchpage}?documentId=${documentServer}&server=${server}${buttonText}${fullscreenScaling}`
   },
-  // TODO: Consider using queryparams to make URL construction less janky⬆ 
+  // TODO: Consider using queryparams to make URL construction less janky⬆
 
   // adapted from https://github.com/sudodoki/copy-to-clipboard/blob/master/index.js
   copy(e) {
@@ -253,10 +247,6 @@ export default createReactClass({
     return this.setState({serverUrl: event.target.value})
   },
 
-  changedCFMOrigin(event) {
-    return this.setState({CFMOrigin: event.target.value})
-  },
-
   changedLaunchButtonText(event) {
     return this.setState({
       launchButtonText: event.target.value})
@@ -343,12 +333,6 @@ export default createReactClass({
                         this.state.serverUrlLabel,
                         (div({},
                           (input({value: this.state.serverUrl, onChange: this.changedServerUrl}))
-                        ))
-                      )),
-                      (div({className: 'cfm-origin'},
-                        this.state.CFMOriginLabel,
-                        (div({},
-                          (input({value: this.state.CFMOrigin, onChange: this.changedCFMOrigin}))
                         ))
                       )),
                       (div({className: 'autolaunch'},

--- a/src/code/views/share-dialog-view.js
+++ b/src/code/views/share-dialog-view.js
@@ -13,7 +13,6 @@ const SHOW_LONGEVITY_WARNING = false
 
 import modalDialogView from './modal-dialog-view'
 const ModalDialog = createReactFactory(modalDialogView)
-import getQueryParam  from '../utils/get-query-param'
 import {ShareLoadingView} from './share-loading-view'
 
 // This function is named "tr" elsewhere in this codeline.
@@ -63,10 +62,8 @@ export default createReactClass({
     return {
       link: this.getShareLink(),
       embed: this.getEmbed(),
-      pageType: "autolaunch",
       serverUrl: this.props.settings.serverUrl || "https://codap.concord.org/releases/latest/",
       serverUrlLabel: this.props.settings.serverUrlLabel || translate("~SHARE_DIALOG.LARA_CODAP_URL"),
-      launchButtonText: "Launch",
       fullscreenScaling: true,
       graphVisToggles: false,
       tabSelected: 'link',
@@ -109,23 +106,6 @@ export default createReactClass({
     }
   },
 
-  getLegacyLara() {
-    const sharedDocumentId = this.getSharedDocumentId()
-    if (sharedDocumentId) {
-      let documentServer = getQueryParam('documentServer') || 'https://document-store.concord.org'
-      while (documentServer.substr(-1) === '/') { documentServer = documentServer.slice(0, -1) }  // remove trailing slash
-      const graphVisToggles = this.state.graphVisToggles ? '?app=is' : ''
-      // graphVisToggles is a parameter handled by CODAP, so it needs to be added to its URL.
-      const server = encodeURIComponent(this.state.serverUrl + graphVisToggles)
-      // Other params are handled by document server itself:
-      const buttonText = this.state.pageType === 'launch' ? `&buttonText=${encodeURIComponent(this.state.launchButtonText)}` : ''
-      const fullscreenScaling = (this.state.pageType === 'autolaunch') && this.state.fullscreenScaling ? '&scaling' : ''
-      return `${documentServer}/v2/documents/${sharedDocumentId}/${this.state.pageType}?server=${server}${buttonText}${fullscreenScaling}`
-    } else {
-      return null
-    }
-  },
-
   getLara() {
     // Update the LARA share link as per this story:
     // https://www.pivotaltracker.com/story/show/172302663
@@ -147,10 +127,9 @@ export default createReactClass({
     // graphVisToggles is a parameter handled by CODAP, so it needs to be added to its URL.
     const server = encodeURIComponent(`${this.state.serverUrl}${graphVisToggles}`)
     // Other params are handled by document server itself:
-    const buttonText = this.state.pageType === 'launch' ? `&buttonText=${encodeURIComponent(this.state.launchButtonText)}` : ''
-    const fullscreenScaling = (this.state.pageType === 'autolaunch') && this.state.fullscreenScaling ? '&scaling' : ''
+    const fullscreenScaling = this.state.fullscreenScaling ? '&scaling' : ''
 
-    return `${autoLaunchpage}?documentId=${documentServer}&server=${server}${buttonText}${fullscreenScaling}`
+    return `${autoLaunchpage}?documentId=${documentServer}&server=${server}${fullscreenScaling}`
   },
   // TODO: Consider using queryparams to make URL construction less janky⬆
 
@@ -247,16 +226,6 @@ export default createReactClass({
     return this.setState({serverUrl: event.target.value})
   },
 
-  changedLaunchButtonText(event) {
-    return this.setState({
-      launchButtonText: event.target.value})
-  },
-
-  changedAutoscalingPage(event) {
-    return this.setState({
-      pageType: event.target.checked ? 'autolaunch' : 'launch'})
-  },
-
   changedFullscreenScaling(event) {
     return this.setState({
       fullscreenScaling: event.target.checked})
@@ -335,20 +304,10 @@ export default createReactClass({
                           (input({value: this.state.serverUrl, onChange: this.changedServerUrl}))
                         ))
                       )),
-                      (div({className: 'autolaunch'},
-                        (input({type: 'checkbox', checked: this.state.pageType === 'autolaunch', onChange: this.changedAutoscalingPage})),
-                        translate("~SHARE_DIALOG.LARA_AUTOLAUNCH_PAGE")
+                      (div({className: 'fullsceen-scaling'},
+                        (input({type: 'checkbox', checked: this.state.fullscreenScaling, onChange: this.changedFullscreenScaling})),
+                        translate("~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING")
                       )),
-                      this.state.pageType === 'autolaunch' ?
-                        (div({className: 'fullsceen-scaling'},
-                          (input({type: 'checkbox', checked: this.state.fullscreenScaling, onChange: this.changedFullscreenScaling})),
-                          translate("~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING")
-                        )) : undefined,
-                      this.state.pageType === 'launch' ?
-                        (div({className: 'launch-button-text'},
-                          translate("~SHARE_DIALOG.LARA_LAUNCH_BUTTON_TEXT"),
-                          (input({value: this.state.launchButtonText, onChange: this.changedLaunchButtonText}))
-                        )) : undefined,
                       (div({},
                         (input({type: 'checkbox', checked: this.state.graphVisToggles, onChange: this.changedGraphVisToggles})),
                         translate("~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES")


### PR DESCRIPTION
PT story provides more detail why it's removed:
https://www.pivotaltracker.com/story/show/173755317
If necessary, we can edit the share URL manually.

I've also removed UI related to launch page that isn't supported anymore. 