### PR TITLE
Fix linked interactives, LARA Embed URL construction

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "start": "npm-run-all --parallel watch:server watch:build",
     "start:secure": "npm-run-all --parallel watch:server:secure watch:build",
     "watch:build": "webpack --watch --mode development",
-    "watch:server": "live-server --port=8888 ./dist --open=examples",
+    "watch:server": "live-server --host=localhost --port=8888 ./dist --open=examples",
     "watch:server:secure": "live-server --port=8888 --https=live-server-ssl-config.js ./dist --open=examples",
     "test:local": "cypress open --env testEnv=local",
     "test": "jest",

--- a/src/code/providers/lara-provider.js
+++ b/src/code/providers/lara-provider.js
@@ -480,24 +480,22 @@ class LaraProvider extends ProviderInterface {
       // This includes the CODAP part of the URL, (TBD: has this always been the case?)
 
       // See if the `#shared` hash parameter looks like a public URL:
-      const sourceUrl = queryString.parseUrl(sourceID, {parseFragmentIdentifier: true})
-      const parsedHash = queryString.parse(sourceUrl.fragmentIdentifier)
-      const sharedDocParam = parsedHash?.shared
       const S3MatchRegex = /^http?s/
-      const sharedDocIsUrl = sharedDocParam && sharedDocParam.match(S3MatchRegex)
+      const sharedDocIsUrl = (typeof sourceID === "string") && sourceID.match(S3MatchRegex)
 
       // The `#shared` hash param is a public URL, just read the contents
       // and use that as the post body to v2CreateDocument.
       if (sharedDocIsUrl) {
         $.ajax({
-          url: sharedDocParam,
+          url: sourceID,
         })
         .done((data) => {
           const {method, url} = this.docStoreUrl.v2CreateDocument({})
+          const dataJson = typeof(data) === "string" ? data : JSON.stringify(data)
           return $.ajax({
             type: method,
             dataType: 'json',
-            data,
+            data: dataJson,
             url
           })
           .done(afterCreateCopy)

--- a/src/code/views/share-dialog-view.js
+++ b/src/code/views/share-dialog-view.js
@@ -83,15 +83,11 @@ export default createReactClass({
     const shared = client.isShared()
     const sharedDocumentUrl = client.state?.currentContent?.get("sharedDocumentUrl")
     const sharedDocumentId = this.getSharedDocumentId()
-    const useInternalLink = true
     if (shared) {
       if(sharedDocumentUrl) {
-        return `${this.props.client.getCurrentUrl()}#shared=${encodeURI(sharedDocumentUrl)}`
+        return sharedDocumentUrl
       }
       if(sharedDocumentId) {
-        if(useInternalLink) {
-          return `${this.props.client.getCurrentUrl()}#shared=${sharedDocumentId}`
-        }
         return getLegacyUrl(sharedDocumentId)
       }
     }
@@ -114,7 +110,7 @@ export default createReactClass({
     //  `<AutoLaunchPageUrl>?documentId=<XX>&server=<CODAP SERVER>&scaling`
     // <AutoLaunchPageUrl> expects a `documentId` param (was a path in DocStore)
     //    and a `server` param, that points usually to some CODAP release.
-    // <CODAP SERVER> can have url encoded params too such as `FcfmBaseUrl=`
+    // <CODAP SERVER> can have url encoded params too such as `cfmBaseUrl=`
     // where URL is the url to the /js folder for CFM
     //
     // It will point to SPA hosted in this repo -- NP 2020-06-29


### PR DESCRIPTION
This fixes the bug with linked interactive URLs in the LARA provider using document-server (numeric) ids.

It also fixes a bug with overly complex links being generated by `getShareLink` in `share-dialog-view.js`

For the migration task:

The `new_url` format for the migration of authored interactives is this:

https://<CFM_URL>/autolaunch/autolaunch.html
 ?documentId=<url-encoded https://models-resources.concord.org/Flegacy-document-store/<LEGACY_ID>>
 &server=<CODAP_URL> (we had been including cfmBaseUrl, but I don't think we need to)
 &scaling

eg:

```JSON
{
    "id": 207249,
    "old_url": "https://document-store.concord.org/v2/documents/16046/autolaunch?server=https%3A%2F%2Fcodap.concord.org%2Freleases%2Flatest%2F&buttonText=Launch",
    "new_url": "https://cloud-file-manager.concord.org/branch/master/autolaunch/autolaunch.html?documentId=https%3A%2F%2Fmodels-resources.concord.org%2Flegacy-document-store%2F16046&scaling=true&server=https%3A%2F%2Fcodap.concord.org%2Freleases%2Fstaging%2F"
}
```

This commit also allows live-server to bind to 'localhost' for an address.