### PR TITLE
Fix JQuery JSON PUT request to Docstore on S3 Copy

### DIFF
--- a/src/code/providers/lara-provider.js
+++ b/src/code/providers/lara-provider.js
@@ -497,7 +497,10 @@ class LaraProvider extends ProviderInterface {
             dataType: 'json',
             contentType: 'application/json', // Document Store requires JSON currently
             processData: false, // https://api.jquery.com/jquery.ajax/
-            data: dataJson,
+            data: pako.deflate(dataJson),
+            beforeSend(xhr) {
+              return xhr.setRequestHeader('Content-Encoding', 'deflate')
+            },
             url
           })
           .done(afterCreateCopy)

--- a/src/code/providers/lara-provider.js
+++ b/src/code/providers/lara-provider.js
@@ -495,6 +495,8 @@ class LaraProvider extends ProviderInterface {
           return $.ajax({
             type: method,
             dataType: 'json',
+            contentType: 'application/json', // Document Store requires JSON currently
+            processData: false, // https://api.jquery.com/jquery.ajax/
             data: dataJson,
             url
           })


### PR DESCRIPTION
JQuery was converting JSON documents into multipart form documents, and breaking Rack's upper limit on number of parameter keys.

[#173950259]