### PR TITLE
Fixed shared url encoding in share dialog [#174342352]

### DIFF
--- a/src/code/views/share-dialog-view.js
+++ b/src/code/views/share-dialog-view.js
@@ -100,7 +100,7 @@ export default createReactClass({
   getShareLink() {
     const shareRef = this.getShareUrl()
     if (shareRef) {
-      return `${this.props.client.getCurrentUrl()}#shared=${encodeURI(shareRef)}`
+      return `${this.props.client.getCurrentUrl()}#shared=${encodeURIComponent(shareRef)}`
     }
     return null
   },


### PR DESCRIPTION
The dialog was using encodeURI instead of encodeURIComponent. The encodeURI() function encodes special characters, except: , / ? : @ & = + $ # whereas encodeURIComponent() function encodes special characters and in additional the characters which encodeURI doesn't encode.