### PR TITLE
Fixed missing dropdown anchor that broke menu styling [#174342649]

### DIFF
--- a/src/code/views/menu-bar-view.js
+++ b/src/code/views/menu-bar-view.js
@@ -7,15 +7,11 @@
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 import DropDownView from "./dropdown-view"
-import DropDownAnchor from "./dropdown-view"
+import {TriangleOnlyAnchor} from './dropdown-anchors'
 import tr  from '../utils/translate'
-
-
 
 const {div, i, span, input} = ReactDOMFactories
 const Dropdown = createReactFactory(DropDownView)
-const {TriangleOnlyAnchor} = DropDownAnchor
-
 
 export default createReactClass({
 


### PR DESCRIPTION
As part of the TypeScript conversion the dropdown anchor reference was broken which caused it not to render which then threw off the styling of the language menu.

CODAP does need to increase their menubar size to give some "breathing space" to the menubar as all the elements (along with the language menu) are butted up on the bottom.  Changing from 24px to 28px here makes it much nicer:

https://github.com/concord-consortium/codap/blob/0aa6c7a9d835a5d6b3f9ca05164ba01dceed8e41/apps/dg/resources/main_page.js#L26