### PR TITLE
[#175445858] CFM sets wrong Chinese variant...

### DIFF
--- a/src/code/utils/translate.js
+++ b/src/code/utils/translate.js
@@ -58,7 +58,7 @@ const getFirstBrowserLanguage = function() {
 
 const translations =  {}
 languageFiles.forEach(function(lang) {
-  translations[lang.key] = lang.contents
+  translations[lang.key.toLowerCase()] = lang.contents
   // accept full key with region code or just the language code
   const baseLang = getBaseLanguage(lang.key)
   if (baseLang && !translations[baseLang]) {
@@ -68,7 +68,8 @@ languageFiles.forEach(function(lang) {
 
 const lang = urlParams.lang || getPageLanguage() || getFirstBrowserLanguage()
 const baseLang = getBaseLanguage(lang || '')
-const defaultLang = lang && translations[lang] ? lang : baseLang && translations[baseLang] ? baseLang : "en"
+// CODAP/Sproutcore lower cases language in documentElement
+const defaultLang = lang && translations[lang.toLowerCase()] ? lang : baseLang && translations[baseLang] ? baseLang : "en"
 
 console.log(`CFM: using ${defaultLang} for translation (lang is "${urlParams.lang}" || "${getFirstBrowserLanguage()}")`);
 


### PR DESCRIPTION
...when Traditional writing system selected.

Sproutcore sets the language in the DocumentElement. It lower cases the name (it expects it to be language only). The CFM determines locale by checking, among other things, the DocumentElement setting. It was failing to match with 'zh-TW'. We adjust the CFM to do a case insensitive mapping.