### PR TITLE
Fixed broken language translation

### DIFF
--- a/src/code/utils/translate.js
+++ b/src/code/utils/translate.js
@@ -80,6 +80,7 @@ const varRegExp = /%\{\s*([^}\s]*)\s*\}/g
 const translate = function(key, vars, lang) {
   if (vars == null) { vars = {} }
   if (lang == null) { lang = defaultLang }
+  lang = lang.toLowerCase()
   let translation = translations[lang] != null ? translations[lang][key] : undefined
   if ((translation == null)) { translation = key }
   return translation.replace(varRegExp, function(match, key) {


### PR DESCRIPTION
An earlier merged commit lowercased the language key before filling the translation tables but the language key was not then also lowercased when a translation was looked up causing en-US and zh-TW to fail.