### PR TITLE
Fix loading of Google Drive API so that we only load it once

### DIFF
--- a/src/code/providers/google-drive-provider.test.ts
+++ b/src/code/providers/google-drive-provider.test.ts
@@ -1,0 +1,36 @@
+import { CloudFileManagerClient } from "../client"
+import GoogleDriveProvider from "./google-drive-provider"
+
+describe('GoogleDriveProvider', () => {
+
+  const clientId = 'mockClientId'
+  const apiKey = 'mockApiKey'
+
+  const client = new CloudFileManagerClient()
+
+  beforeEach(() => {
+    GoogleDriveProvider.loadPromise = null
+  })
+
+  it('should throw exception without credentials', () => {
+    expect(() => new GoogleDriveProvider({} as any, client)).toThrow()
+    expect(() => new GoogleDriveProvider({ clientId } as any, client)).toThrow()
+    expect(() => new GoogleDriveProvider({ apiKey } as any, client)).toThrow()
+    expect(() => new GoogleDriveProvider({ clientId, apiKey }, client)).not.toThrow()
+  })
+
+  it('should load the google API only once', () => {
+    const createElementSpy = jest.spyOn(document, 'createElement')
+    const appendChildSpy = jest.spyOn(document.head, 'appendChild').mockImplementation(() => null)
+    const provider = new GoogleDriveProvider({ clientId, apiKey }, client)
+    expect(createElementSpy).toHaveBeenCalledTimes(1)
+    expect(createElementSpy.mock.results[0].value.src).toBe('https://apis.google.com/js/api.js')
+    expect(appendChildSpy).toHaveBeenCalledTimes(1)
+    const promise1 = GoogleDriveProvider.loadPromise
+    const promise2 = provider._waitForGAPILoad()
+    expect(createElementSpy).toHaveBeenCalledTimes(1)
+    expect(appendChildSpy).toHaveBeenCalledTimes(1)
+    expect(promise1).toBe(promise2)
+  })
+
+})

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -74,6 +74,7 @@ class GoogleDriveProvider extends ProviderInterface {
   static Name = 'googleDrive'
   static IMMEDIATE = true
   static SHOW_POPUP = false
+  static loadPromise: Promise<unknown> = null
   _autoRenewTimeout: number
   apiKey: string
   authCallback: (authorized: boolean) => void
@@ -300,7 +301,7 @@ class GoogleDriveProvider extends ProviderInterface {
   }
 
   _waitForGAPILoad() {
-    return new Promise((resolve, reject) => {
+    return GoogleDriveProvider.loadPromise || (GoogleDriveProvider.loadPromise = new Promise((resolve, reject) => {
       const script = document.createElement('script')
       script.src = "https://apis.google.com/js/api.js"
       script.onload = () => {
@@ -316,7 +317,7 @@ class GoogleDriveProvider extends ProviderInterface {
         })
       }
       document.head.appendChild(script)
-    })
+    }))
   }
 
   _loadFile(metadata: CloudMetadata, callback: ProviderLoadCallback) {


### PR DESCRIPTION
[[#178634302]](https://www.pivotaltracker.com/story/show/178634302)

In working through the TypeScript conversion I noticed that the GoogleDriveProvider was loading an instance of the Google Drive API in every function call rather than caching the result of the first load and returning it for all subsequent loads. This PR makes sure we only load the Google Drive API once, in consultation with @dougmartin, and also includes a jest test which in good TDD fashion was written before the fix was implemented.