### PR TITLE
Fix auto-configuration of InteractiveApiProvider

### DIFF
--- a/src/code/client.test.ts
+++ b/src/code/client.test.ts
@@ -40,10 +40,12 @@ describe("CloudFileManagerClient", () => {
       ]
     }
     client.setAppOptions(options)
-    expect(Object.keys(client.providers).length).toBe(3)
+    expect(Object.keys(client.providers).length).toBe(4)
     expect(client.providers.localStorage.name).toBe('localStorage')
     expect(client.providers.localFile.name).toBe('localFile')
     expect(client.providers.lara.name).toBe('lara')
+    // InteractiveApiProvider should be included when LaraProvider is specified
+    expect(client.providers.interactiveApi.name).toBe('interactiveApi')
     expect(availableProvidersIncludes(client, 'localStorage')).toBe(true)
     expect(availableProvidersIncludes(client, 'localFile')).toBe(true)
     expect(availableProvidersIncludes(client, 'lara')).toBe(true)

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -202,7 +202,9 @@ class CloudFileManagerClient {
 
             // InteractiveApiProvider is a newer form of Lara provider
             if (!isInteractiveApiRequested && (providerName === "lara")) {
-              availableProviders.push(new InteractiveApiProvider(providerOptions, this))
+              const interactiveApiProvider = new InteractiveApiProvider(providerOptions, this)
+              this.providers.interactiveApi = interactiveApiProvider
+              availableProviders.push(interactiveApiProvider)
             }
           }
         } else {


### PR DESCRIPTION
The good news is that I was able to create an example activity that demonstrates unmodified production CODAP saving/restoring files using attachments. To get it to work, however, one more tweak to provider initialization is required.