### PR TITLE
Working save/restore of CODAP documents as attachments

### DIFF
--- a/build-support/build-opts.js
+++ b/build-support/build-opts.js
@@ -38,16 +38,16 @@ if (codap) {
       replace: 'static_url('
     },
     {
-      search: /\.\.\/fonts/g,
-      replace: 'webfonts'
+      search: /fonts\//g,
+      replace: 'webfonts/'
     },
     {
       search: /MuseoSans_500_italic/g,
       replace: 'MuseoSans_500_Italic'
     },
     {
-      search: /\.\.\/img/g,
-      replace: 'cloud-file-manager/img'
+      search: /img\//g,
+      replace: 'cloud-file-manager/img/'
     }
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6019,6 +6019,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -9269,6 +9270,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
       "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       },
@@ -9276,7 +9278,8 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -9311,6 +9314,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -12316,6 +12320,7 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.4.tgz",
       "integrity": "sha512-kcPWrO8S5ABjuZ/v1xQHP8xCEvj1dQ1d9iAb6Qs4jLYzaAIYWwST2IQpz7Ud8VNYRI+fGhFjrnzRKmRggKWg3g==",
+      "dev": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -12328,12 +12333,14 @@
         "chownr": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
         },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
         }
       }
     },
@@ -13636,7 +13643,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1159,11 +1159,11 @@ class CloudFileManagerClient {
 
   _fileOpened(content: any, metadata: CloudMetadata, additionalState?: any, hashParams: string = null) {
     if (additionalState == null) { additionalState = {} }
-    const eventData = { content: (content != null ? content.getClientContent() : undefined) }
+    const eventData = { content: content?.getClientContent?.() ?? content }
     // update state before sending 'openedFile' events so that 'openedFile' listeners that
     // reference state have the updated state values
     this._updateState(content, metadata, additionalState, hashParams)
-    // add metadata contentType to event for CODAP to load via postmessage API (for SageModeler standalone)
+    // add metadata contentType to event for CODAP to load via postMessage API (for SageModeler standalone)
     const contentType = metadata.mimeType || metadata.contentType;
     (eventData as any).metadata = {contentType, url: metadata.url, filename: metadata.filename}
     return this._event('openedFile', eventData, (iError: string | null, iSharedMetadata: any) => {

--- a/src/code/providers/interactive-api-provider.test.ts
+++ b/src/code/providers/interactive-api-provider.test.ts
@@ -405,7 +405,6 @@ describe('InteractiveApiProvider', () => {
     setQueryParams(`interactiveApi=${kDynamicAttachmentUrlParameter}`)
 
     const client = new CloudFileManagerClient()
-    CloudContent.wrapFileContent = false
     const content = new CloudContent('fooContent', { isCfmWrapped: false, isPreCfmFormat: false })
     const metadata = new CloudMetadata({ name: 'foo' })
     const provider = new InteractiveApiProvider({}, client)

--- a/src/code/providers/provider-interface.ts
+++ b/src/code/providers/provider-interface.ts
@@ -276,9 +276,7 @@ class CloudContent {
 
   // returns the client-visible content (excluding wrapper for wrapped clients)
   getClientContent() {
-    return CloudContent.wrapFileContent
-            ? this.content.content
-            : this.content
+    return this.content.content ?? this.content
   }
 
   requiresConversion() {


### PR DESCRIPTION
In setting up example activities for testing purposes I realized there was some confusion around wrapping/unwrapping attachment contents that was preventing save/restore of CODAP documents from working correctly.

The following URLs demonstrate the functionality:

CFM Demo saving with attachments:
https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring.staging.concord.org%2Fapi%2Fv1%2Factivities%2F21112.json

CODAP saving without attachments (subject to Firestore 1MB document size limit):
https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring.staging.concord.org%2Fapi%2Fv1%2Factivities%2F21118.json

CODAP saving with attachments:
https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring.staging.concord.org%2Fapi%2Fv1%2Factivities%2F21115.json

CODAP saving with dynamic attachments (large documents (>= ~480K) saved as attachments while smaller documents are stored directly to Firestore). This hasn't really been tested but theoretically should work:
https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring.staging.concord.org%2Fapi%2Fv1%2Factivities%2F21119.json

NOTE: I'm not entirely sure why the CSS string path changes were required, but I assume they're the result of some of the dependency updating I did earlier. It only affects the codap build.