### PR TITLE
Fix bug in loading contents of shared CODAP documents via InteractiveApiProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^1.1.2",
+    "@concord-consortium/lara-interactive-api": "1.1.2",
     "@concord-consortium/token-service": "^2.0.0",
     "aws-sdk": "^2.958.0",
     "base64-js": "^1.5.1",

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -1,4 +1,5 @@
 import queryString from 'query-string'
+import { cloneDeep } from 'lodash'
 import React from 'react'
 import { CFMLaraProviderOptions, CFMLaraProviderLogData } from '../app-options'
 import { CloudFileManagerClient } from '../client'
@@ -7,9 +8,12 @@ import {
   ProviderLoadCallback, ProviderOpenCallback, ProviderSaveCallback
 }  from './provider-interface'
 import {
-  getInitInteractiveMessage, getInteractiveState, IRuntimeInitInteractive,
-  readAttachment, setInteractiveState, writeAttachment
+  getInitInteractiveMessage, getInteractiveState as _getInteractiveState, IRuntimeInitInteractive,
+  readAttachment, setInteractiveState as _setInteractiveState, writeAttachment
 } from '@concord-consortium/lara-interactive-api'
+const getInteractiveState = () => cloneDeep(_getInteractiveState())
+const setInteractiveState = <InteractiveState>(newState: InteractiveState | null) =>
+        _setInteractiveState(cloneDeep(newState))
 
 interface InteractiveApiProviderParams {
   documentId?: string;
@@ -128,6 +132,7 @@ class InteractiveApiProvider extends ProviderInterface {
   async readAttachmentContent(interactiveState: InteractiveStateAttachment) {
     const response = await readAttachment(interactiveState.__attachment__)
     if (response.ok) {
+      // TODO: Scott suggests reading contentType from response rather than from interactiveState
       return interactiveState.contentType === "application/json" ? response.json() : response.text()
     }
     else {


### PR DESCRIPTION
This is essentially an alternative fix for @tejal-shah's bug ([[#172312303]](https://www.pivotaltracker.com/story/show/172312303)). The problem is that the state object communicated between the CFM and its client (CODAP in this case) needs be cloned so that it isn't frozen by the `lara-interactive-api` library. [LARA PR #736](https://github.com/concord-consortium/lara/pull/736) demonstrates what this would look like if we made the library responsible for cloning the state. If we decide not to do so in the library, then this PR demonstrates how it could be done in the client.