### PR TITLE
Changed CFM to wait for either local or iframe connected before opening provider file

### DIFF
--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1309,6 +1309,7 @@ class CloudFileManagerClient {
         case 'cfm::setDirty':
           return this.dirty(data.isDirty)
         case 'cfm::iframedClientConnected':
+          this.connectedPromiseResolver?.resolve();
           return this.processUrlParams()
       }
     })

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1309,7 +1309,7 @@ class CloudFileManagerClient {
         case 'cfm::setDirty':
           return this.dirty(data.isDirty)
         case 'cfm::iframedClientConnected':
-          this.connectedPromiseResolver?.resolve();
+          this.connectedPromiseResolver?.resolve()
           return this.processUrlParams()
       }
     })


### PR DESCRIPTION
Before this was only waiting on connected which is never send when the CFM is in "wrapper" mode like it is used in SageModeler