### PR TITLE
[#177118798] Fix typo in CFM google provider error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/concord-consortium/cloud-file-manger"

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -388,12 +388,12 @@ class GoogleDriveProvider extends ProviderInterface {
     return request.execute((file: any) => {
       if (callback) {
         if (file != null ? file.error : undefined) {
-          return callback(`Unabled to upload file: ${file.error.message}`)
+          return callback(tr("~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG", {message: file.error.message}))
         } else if (file) {
           metadata.providerData = {id: file.id}
           return callback(null, file)
         } else {
-          return callback(this._apiError(file, 'Unabled to upload file'))
+          return callback(this._apiError(file, tr("~GOOGLE_DRIVE.UNABLE_TO_UPLOAD")))
         }
       }
     })

--- a/src/code/utils/lang/de.json
+++ b/src/code/utils/lang/de.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/de.json
+++ b/src/code/utils/lang/de.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "Retrying...",
     "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/el.json
+++ b/src/code/utils/lang/el.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/el.json
+++ b/src/code/utils/lang/el.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "Retrying...",
     "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -126,6 +126,8 @@
   "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
   "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
   "~GOOGLE_DRIVE.ERROR_MISSING_CLIENTID": "Missing required clientId in googleDrive provider options",
+  "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+  "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
 
   "~DOCSTORE.LOAD_403_ERROR": "You don't have permission to load %{filename}.<br><br>If you are using some else's shared document it may have been unshared.",
   "~DOCSTORE.LOAD_SHARED_404_ERROR": "Unable to load the requested shared document.<br><br>Perhaps the file was not shared?",

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -79,6 +79,7 @@
   "~SHARE_DIALOG.LINK_MESSAGE": "Paste this into an email or text message ",
   "~SHARE_DIALOG.EMBED_TAB": "Embed",
   "~SHARE_DIALOG.EMBED_MESSAGE": "Embed code for including in webpages or other web-based content",
+  "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player",
   "~SHARE_DIALOG.LARA_MESSAGE": "Use this link when creating an activity in LARA",
   "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
   "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -79,6 +79,7 @@
   "~SHARE_DIALOG.LINK_MESSAGE": "Paste this into an email or text message ",
   "~SHARE_DIALOG.EMBED_TAB": "Embed",
   "~SHARE_DIALOG.EMBED_MESSAGE": "Embed code for including in webpages or other web-based content",
+  "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player",
   "~SHARE_DIALOG.LARA_MESSAGE": "Use this link when creating an activity in LARA",
   "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
   "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -83,7 +83,6 @@
   "~SHARE_DIALOG.LARA_CODAP_URL": "CODAP Server URL:",
   "~SHARE_DIALOG.LARA_FULLSCREEN_BUTTON_AND_SCALING": "Fullscreen button and scaling",
   "~SHARE_DIALOG.LARA_DISPLAY_VISIBILITY_TOGGLES": "Display data visibility toggles on graphs",
-  "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player",
   "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
 
   "~SHARE_UPDATE.TITLE": "Shared View Updated",
@@ -127,6 +126,8 @@
   "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
   "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
   "~GOOGLE_DRIVE.ERROR_MISSING_CLIENTID": "Missing required clientId in googleDrive provider options",
+  "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+  "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
 
   "~DOCSTORE.LOAD_403_ERROR": "You don't have permission to load %{filename}.<br><br>If you are using some else's shared document it may have been unshared.",
   "~DOCSTORE.LOAD_SHARED_404_ERROR": "Unable to load the requested shared document.<br><br>Perhaps the file was not shared?",
@@ -147,3 +148,4 @@
   "~CONCORD_CLOUD_DEPRECATION.SHUT_DOWN_MESSAGE": "The Concord Cloud has been shut down!",
   "~CONCORD_CLOUD_DEPRECATION.PLEASE_SAVE_ELSEWHERE": "Please save your documents to another location."
 }
+

--- a/src/code/utils/lang/es.json
+++ b/src/code/utils/lang/es.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/es.json
+++ b/src/code/utils/lang/es.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "Reintento..",
     "~SHARE_DIALOG.PLEASE_WAIT": "Por favor espere mientras se genera el enlace...",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/he.json
+++ b/src/code/utils/lang/he.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/he.json
+++ b/src/code/utils/lang/he.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "Retrying...",
     "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/ja.json
+++ b/src/code/utils/lang/ja.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/ja.json
+++ b/src/code/utils/lang/ja.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "再接続しています…",
     "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/nb.json
+++ b/src/code/utils/lang/nb.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/nb.json
+++ b/src/code/utils/lang/nb.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "Retrying...",
     "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/nn.json
+++ b/src/code/utils/lang/nn.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/nn.json
+++ b/src/code/utils/lang/nn.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "Retrying...",
     "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/th.json
+++ b/src/code/utils/lang/th.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "กำลังลองใหม่...",
     "~SHARE_DIALOG.PLEASE_WAIT": "โปรดรอ..กำลังสร้างลิงก์แชร์",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "ล้มเหลวในการเชื่อมต่อ Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/th.json
+++ b/src/code/utils/lang/th.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "ล้มเหลวในการเชื่อมต่อ Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/tr.json
+++ b/src/code/utils/lang/tr.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/tr.json
+++ b/src/code/utils/lang/tr.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "Retrying...",
     "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/zh-Hans.json
+++ b/src/code/utils/lang/zh-Hans.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "重试...",
     "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }

--- a/src/code/utils/lang/zh-Hans.json
+++ b/src/code/utils/lang/zh-Hans.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/zh-TW.json
+++ b/src/code/utils/lang/zh-TW.json
@@ -124,5 +124,6 @@
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
     "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
     "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
-    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}",
+    "~SHARE_DIALOG.INTERACTIVE_API_MESSAGE": "Use this link when creating an activity for the Activity Player"
 }

--- a/src/code/utils/lang/zh-TW.json
+++ b/src/code/utils/lang/zh-TW.json
@@ -122,5 +122,7 @@
     "~FILE_STATUS.FAILURE": "Retrying...",
     "~SHARE_DIALOG.PLEASE_WAIT": "Please wait while we generate a shared link …",
     "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
-    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options"
+    "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD": "Unable to upload file",
+    "~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG": "Unable to upload file: %{message}"
 }


### PR DESCRIPTION
* Also, add message to strings file so it can be localized.
* Updated minor version number
* Tested in CODAP: 
    * saved a file to Google Drive, 
    * then disabled wireless network, 
    * then made a change to the CODAP docuument: saw correct error message.