### PR TITLE
Prevent save of undefined content [#179610900]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-file-manager",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/concord-consortium/cloud-file-manger"

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1132,7 +1132,7 @@ class CloudFileManagerClient {
   }
 
   _dialogSave(stringContent: any, metadata: CloudMetadata, callback: OpenSaveCallback) {
-    if (stringContent !== null) {
+    if (stringContent != null) {
       return this.saveFileNoDialog(stringContent, metadata, callback)
     } else {
       return this._event('getContent', { shared: this._sharedMetadata() }, (stringContent: any) => {


### PR DESCRIPTION
[#179610900]

For reasons not entirely understood (yet), recent CFM changes introduced a bug in which the first save of a document to google drive would be invalid, but subsequent saves would be fine. The proximate cause of the bug was that `undefined` was being passed to the `_dialogSave()` function, which had an explicit test of the form `if (stringContent !== null)`. Since in this case the content was `undefined` and not `null`, we proceeded to save the `undefined` content rather than retrieving and saving the actual content.

In the interest of expediency, the fix here is to change the test to `if (stringContent != null)` so that `undefined` and `null` are both handled the same way, i.e. by retrieving and saving the actual content. For general edification and posterity, a little more time will be spent trying to understand precisely how the recent changes got us here, but for now this should be good enough to get a build into testing.