### PR TITLE
Call cloneDeep() on initialState

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-file-manager",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/concord-consortium/cloud-file-manger"

--- a/src/code/providers/interactive-api-provider.test.ts
+++ b/src/code/providers/interactive-api-provider.test.ts
@@ -247,7 +247,7 @@ describe('InteractiveApiProvider', () => {
     mockApi.getInitInteractiveMessage
       .mockImplementation(() => Promise.resolve(mockInitInteractiveMessage))
 
-    // fetch response is intial interactive state
+    // fetch response is initial interactive state
     setQueryParams("documentId=https://initial/state")
     mockFetch.mockImplementation(() => ({ ok: true }))
 
@@ -308,7 +308,7 @@ describe('InteractiveApiProvider', () => {
     mockApi.getInitInteractiveMessage
       .mockImplementation(() => Promise.resolve(mockInitInteractiveMessage))
 
-    // fetch response is intial interactive state
+    // fetch response is initial interactive state
     setQueryParams("documentId=https://initial/state")
     mockFetch.mockImplementation(() => ({ ok: false }))
 

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -143,7 +143,7 @@ class InteractiveApiProvider extends ProviderInterface {
   async processRawInteractiveState(interactiveState: any) {
     return isInteractiveStateAttachment(interactiveState)
             ? await this.readAttachmentContent(interactiveState)
-            : interactiveState
+            : cloneDeep(interactiveState)
   }
 
   async handleInitialInteractiveState(initInteractiveMessage: IRuntimeInitInteractive) {


### PR DESCRIPTION
[[#179611084]](https://www.pivotaltracker.com/story/show/179611084)

Having decided not to implement [LARA PR #736](https://github.com/concord-consortium/lara/pull/736), we instead worked around the interactive API's frozen state in [CFM PR #222](https://github.com/concord-consortium/cloud-file-manager/pull/222) by calling `cloneDeep()` in `getInteractiveState()` and `setInteractiveState()`. Unfortunately, this missed the initial interactive state, a situation that is rectified with this PR.

@scytacki I originally assigned this to Piotr for review, forgetting that he's on vacation. It should be a quick review, however, as it's essentially a trivial follow-up to #222.