### PR TITLE
Add support basic Linked Interactive logic  [#175171377]

### DIFF
--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -146,12 +146,20 @@ class InteractiveApiProvider extends ProviderInterface {
             : cloneDeep(interactiveState)
   }
 
+  getInitialInteractiveState(initInteractiveMessage: IRuntimeInitInteractive) {
+    let interactiveState = initInteractiveMessage.interactiveState
+
+    if (!interactiveState && (initInteractiveMessage.hasLinkedInteractive && initInteractiveMessage.linkedState)) {
+      interactiveState = initInteractiveMessage.linkedState
+    }
+
+    return interactiveState
+  }
+
   async handleInitialInteractiveState(initInteractiveMessage: IRuntimeInitInteractive) {
     let interactiveState: any
 
-    const initialInteractiveState = initInteractiveMessage.hasLinkedInteractive && initInteractiveMessage.linkedState
-      ? initInteractiveMessage.linkedState
-      : initInteractiveMessage.interactiveState
+    const initialInteractiveState = this.getInitialInteractiveState(initInteractiveMessage)
 
     try {
       interactiveState = await this.processRawInteractiveState(initialInteractiveState)


### PR DESCRIPTION
I was going to combine this PR with the UI story but I don't have that done so I yanked it out and just have the basic support in this PR.

To see this in action preview this activity in either Lara or AP: 

https://authoring.staging.concord.org/activities/21350

It has SageModeler using CFM master on page 1 and a linked SageModeler interactive with CFM using this branch on page 2.  You should be able to update the text box in the SageModeler area on page 1 and then see the update on page 2.