### PR TITLE
179981050 handle gd auth timeout

### DIFF
--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -505,7 +505,10 @@ class CloudFileManagerClient {
    */
   disconnectCurrentFile() {
     console.log('Closing file (rejected reauth)');
-    this.closeFile();
+    if (this.state.metadata) { this.state.metadata.provider = null; }
+    this._setState({saving: null, saved: null});
+    window.location.hash = "";
+    this._event('ready');
   }
 
   confirmAuthorizeAndOpen(provider: ProviderInterface, providerParams: any) {

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -528,9 +528,9 @@ class CloudFileManagerClient {
   openProviderFile(providerName: string, providerParams?: any) {
     const provider = this.providers[providerName]
     if (provider) {
-      return provider.authorized((authorized: boolean) => {
+      return provider.authorized((isAuthorized: boolean) => {
         // we can open the document without authorization in some cases
-        if (authorized || !provider.isAuthorizationRequired()) {
+        if (isAuthorized || !provider.isAuthorizationRequired()) {
           this._event('willOpenFile', {op: "openProviderFile"})
           return provider.openSaved(providerParams, (err: string | null, content: any, metadata: CloudMetadata) => {
             if (err) {

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -497,13 +497,19 @@ class CloudFileManagerClient {
     }
   }
 
-  closeCurrentFile() {
+  /**
+   * Disassociates the current document from its provider.
+   *
+   * This is important specifically for autosaving providers. When authenticated
+   * state is lost we must not continue to autosave.
+   */
+  disconnectCurrentFile() {
     console.log('Closing file (rejected reauth)');
     this.closeFile();
   }
 
   confirmAuthorizeAndOpen(provider: ProviderInterface, providerParams: any) {
-    let rejectCallback = function () {this.closeCurrentFile();}.bind(this);
+    let rejectCallback = function () {this.disconnectCurrentFile();}.bind(this);
     // trigger authorize() from confirmation dialog to avoid popup blockers
     return this.confirm(tr("~CONFIRM.AUTHORIZE_OPEN"), () => {
         return provider.authorize(() => {
@@ -592,7 +598,7 @@ class CloudFileManagerClient {
   }
 
   confirmAuthorizeAndSave(stringContent: any, callback?: OpenSaveCallback) {
-    let rejectCallback = function () {this.closeCurrentFile();}.bind(this);
+    let rejectCallback = function () {this.disconnectCurrentFile();}.bind(this);
     // trigger authorize() from confirmation dialog to avoid popup blockers
     return this.confirm(tr("~CONFIRM.AUTHORIZE_SAVE"), () => {
       return this.state.metadata.provider.authorize(() => {

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -601,7 +601,7 @@ class CloudFileManagerClient {
   }
 
   confirmAuthorizeAndSave(stringContent: any, callback?: OpenSaveCallback) {
-    let rejectCallback = function () {this.disconnectCurrentFile();}.bind(this);
+    let rejectCallback = function () {this.disconnectCurrentFile();}.bind(this)
     // trigger authorize() from confirmation dialog to avoid popup blockers
     return this.confirm(tr("~CONFIRM.AUTHORIZE_SAVE"), () => {
       return this.state.metadata.provider.authorize(() => {

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -646,8 +646,7 @@ class CloudFileManagerClient {
     return metadata.provider.save(currentContent, metadata, (err: string | null, statusCode: number) => {
       let failures
       if (err) {
-        this._setState({ metadata, saving: null })
-        if (statusCode === 403 || statusCode === 401) {
+        if (statusCode === 401 || statusCode === 403 || statusCode === 404) {
           return this.confirmAuthorizeAndSave(stringContent, callback)
         } else {
           failures = this.state.failures
@@ -661,6 +660,8 @@ class CloudFileManagerClient {
             return this.alert(err)
           }
         }
+        metadata.autoSaveDisabled = true;
+        this._setState({ metadata, saving: null })
       } else {
         this._setState({ failures: 0 })
         if (this.state.metadata !== metadata) {

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1066,7 +1066,7 @@ class CloudFileManagerClient {
       interval = Math.round(interval / 1000)
     }
     if (interval > 0) {
-      return this._autoSaveInterval = window.setInterval((() => { if (this.shouldAutoSave()) { return this.save() } }), interval * 1000)
+      return this._autoSaveInterval = window.setInterval((() => { if (this.shouldAutoSave()) { console.log('autosaving'); return this.save() } }), interval * 1000)
     }
   }
 

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -601,7 +601,7 @@ class CloudFileManagerClient {
   }
 
   confirmAuthorizeAndSave(stringContent: any, callback?: OpenSaveCallback) {
-    let rejectCallback = function () {this.disconnectCurrentFile();}.bind(this)
+    let rejectCallback = () => {this.disconnectCurrentFile()}
     // trigger authorize() from confirmation dialog to avoid popup blockers
     return this.confirm(tr("~CONFIRM.AUTHORIZE_SAVE"), () => {
       return this.state.metadata.provider.authorize(() => {

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -142,9 +142,6 @@ class GoogleDriveProvider extends ProviderInterface {
     if (this.gapiLoadState === ELoadState.loaded && !authCallback) {
       return gapi.auth2.getAuthInstance().isSignedIn.get();
     }
-    if (this.gapiLoadState === ELoadState.loaded && authCallback) {
-      return authCallback(gapi.auth2.getAuthInstance().isSignedIn.get());
-    }
     if (authCallback) {
       if (this.authToken) {
         return authCallback(true)
@@ -173,13 +170,13 @@ class GoogleDriveProvider extends ProviderInterface {
       if (auth.isSignedIn.get()) {
         finishAuthorization()
       } else {
-        auth.isSignedIn.listen((isAuth: boolean) => {
-          if (isAuth) {
-            finishAuthorization()
-          }
-          auth.isSignedIn.listen(() => {});
-        })
         if (!immediate) {
+          auth.isSignedIn.listen((isAuth: boolean) => {
+            if (isAuth) {
+              finishAuthorization()
+            }
+            auth.isSignedIn.listen(() => {});
+          })
           auth.signIn()
         } else {
           finishAuthorization()
@@ -189,9 +186,8 @@ class GoogleDriveProvider extends ProviderInterface {
   }
 
   authorize(callback:any) {
-    this.doAuthorize(!GoogleDriveProvider.IMMEDIATE).then((result) => {
-      if (callback) { callback (result);}
-    });
+    this.authCallback = callback;
+    this.doAuthorize(!GoogleDriveProvider.IMMEDIATE);
   }
 
   autoRenewToken(authToken: any) {

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -191,6 +191,8 @@ class GoogleDriveProvider extends ProviderInterface {
 
   authorize(callback:any) {
     this.authCallback = callback;
+    // Calling doAuthorize with immediate set to false permits an authorization
+    // dialog, if necessary
     this.doAuthorize(!GoogleDriveProvider.IMMEDIATE);
   }
 
@@ -307,9 +309,7 @@ class GoogleDriveProvider extends ProviderInterface {
     })
   }
 
-  close(metadata: CloudMetadata, callback: ProviderCloseCallback) {
-    console.log('Closing GD File');
-  }
+  close(metadata: CloudMetadata, callback: ProviderCloseCallback) {}
     // nothing to do now that the realtime library was removed
 
   canOpenSaved() { return true }

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -173,8 +173,11 @@ class GoogleDriveProvider extends ProviderInterface {
       if (auth.isSignedIn.get()) {
         finishAuthorization()
       } else {
-        auth.isSignedIn.listen(() => {
-          finishAuthorization()
+        auth.isSignedIn.listen((isAuth: boolean) => {
+          if (isAuth) {
+            finishAuthorization()
+          }
+          auth.isSignedIn.listen(() => {});
         })
         if (!immediate) {
           auth.signIn()

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -139,6 +139,12 @@ class GoogleDriveProvider extends ProviderInterface {
    */
   authorized(authCallback: ((authorized: boolean) => void)) {
     if (!(authCallback == null)) { this.authCallback = authCallback }
+    if (this.gapiLoadState === ELoadState.loaded && !authCallback) {
+      return gapi.auth2.getAuthInstance().isSignedIn.get();
+    }
+    if (this.gapiLoadState === ELoadState.loaded && authCallback) {
+      return authCallback(gapi.auth2.getAuthInstance().isSignedIn.get());
+    }
     if (authCallback) {
       if (this.authToken) {
         return authCallback(true)

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -46,7 +46,9 @@ const GoogleDriveAuthorizationDialog = createReactClassFactory({
   },
 
   authenticate() {
-    return this.props.provider.authorize(GoogleDriveProvider.SHOW_POPUP)
+    // we rely on the fact that the prior call to authorized has set the callback
+    // we need here
+    return this.props.provider.authorize(this.props.provider.authCallback)
   },
 
   render() {

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -406,7 +406,7 @@ class GoogleDriveProvider extends ProviderInterface {
     return request.execute((file: any) => {
       if (callback) {
         if (file != null ? file.error : undefined) {
-          return callback(tr("~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG", {message: file.error.message}))
+          return callback(tr("~GOOGLE_DRIVE.UNABLE_TO_UPLOAD_MSG", {message: file.error.message}), file.error.code)
         } else if (file) {
           metadata.providerData = {id: file.id}
           return callback(null, file)

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -134,20 +134,23 @@ class GoogleDriveProvider extends ProviderInterface {
       .catch(() => this.gapiLoadState = ELoadState.errored)  // eslint-disable-line @typescript-eslint/dot-notation
   }
 
-  authorized(authCallback: (authorized: boolean) => void) {
+  /**
+   * Invokes the provided callback with whether there is an authenticated user.
+   */
+  authorized(authCallback: ((authorized: boolean) => void)) {
     if (!(authCallback == null)) { this.authCallback = authCallback }
     if (authCallback) {
       if (this.authToken) {
         return authCallback(true)
       } else {
-        return this.authorize(GoogleDriveProvider.IMMEDIATE)
+        return this.doAuthorize(GoogleDriveProvider.IMMEDIATE)
       }
     } else {
       return this.authToken !== null
     }
   }
 
-  authorize(immediate: boolean) {
+  doAuthorize(immediate: boolean) {
     return this._waitForGAPILoad().then(() => {
       const auth = gapi.auth2.getAuthInstance()
       const finishAuthorization = () => {
@@ -174,6 +177,12 @@ class GoogleDriveProvider extends ProviderInterface {
         }
       }
     })
+  }
+
+  authorize(callback:any) {
+    this.doAuthorize(!GoogleDriveProvider.IMMEDIATE).then((result) => {
+      if (callback) { callback (result);}
+    });
   }
 
   autoRenewToken(authToken: any) {

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -296,7 +296,9 @@ class GoogleDriveProvider extends ProviderInterface {
     })
   }
 
-  close(metadata: CloudMetadata, callback: ProviderCloseCallback) {}
+  close(metadata: CloudMetadata, callback: ProviderCloseCallback) {
+    console.log('Closing GD File');
+  }
     // nothing to do now that the realtime library was removed
 
   canOpenSaved() { return true }

--- a/src/code/views/file-dialog-tab-view.ts
+++ b/src/code/views/file-dialog-tab-view.ts
@@ -12,10 +12,10 @@
 import _ from 'lodash'
 import createReactClass from 'create-react-class'
 import ReactDOMFactories from 'react-dom-factories'
-import { createReactClassFactory } from '../create-react-factory'
-import { CloudMetadata }  from '../providers/provider-interface'
+import {createReactClassFactory} from '../create-react-factory'
+import {CloudMetadata} from '../providers/provider-interface'
 
-import tr  from '../utils/translate'
+import tr from '../utils/translate'
 
 const {div, i, input, button} = ReactDOMFactories
 const italic = i
@@ -175,7 +175,7 @@ const FileDialogTab = createReactClass({
 
   // NP 2020-04-23 Copied from authorize-mixin.js
   render() {
-    if (this._isAuthorized || this.state.authorized) {
+    if (!this.props.provider.isAuthorizationRequired() || this.props.provider.authorized()) {
       return this.renderWhenAuthorized()
     } else {
       return this.props.provider.renderAuthorizationDialog()


### PR DESCRIPTION
- Relevant story here: https://www.pivotaltracker.com/story/show/179981050
- Version number has not yet updated
- The changes affect providers that authenticate, which I think are only GD and the Document Server provider. I did not test the later, but I believe it is not in use any more. I think, for example, that document sharing is provided through another provider.
- These changes were built off of the then head of the `master` branch. This includes code from PR #231, which have not been included in any CODAP build. Although it is on `master`, I am not sure of its readiness for production nor PR #232 which was merged subsequently. If these are ready for release, I can rebase as appropriate.