### PR TITLE
Fixed scaling on linked interactive previews so that it is readable

### DIFF
--- a/src/code/views/select-interactive-state-dialog-view.tsx
+++ b/src/code/views/select-interactive-state-dialog-view.tsx
@@ -47,6 +47,7 @@ class SelectInteractiveStateVersion extends React.Component<IProps, IState> {
     const {version} = this.props
     const updatedAt = (new Date(version.updatedAt)).toLocaleString()
     const previewClassName = `preview${preview ? ' preview-active' : ''}`
+    const previewIframeClassName = preview ? 'preview-iframe-fullsize' : 'preview-iframe'
 
     return (
       <div className='version-info'>
@@ -55,7 +56,7 @@ class SelectInteractiveStateVersion extends React.Component<IProps, IState> {
         </div>
         <div className={previewClassName} onClick={this.handleTogglePreview}>
           <div className='iframe-wrapper'>
-            <iframe className='preview-iframe' src={version.externalReportUrl}></iframe>
+            <iframe className={previewIframeClassName} src={version.externalReportUrl}></iframe>
           </div>
         </div>
         <div className='center preview-label' onClick={this.handleTogglePreview}>

--- a/src/style/components/select-interactive-state-dialog.styl
+++ b/src/style/components/select-interactive-state-dialog.styl
@@ -124,6 +124,13 @@
     transform-origin: left top
     border: solid 1px
 
+  iframe.preview-iframe-fullsize
+    width: 100% !important
+    height: 100% !important
+    transform: scale3d(1, 1, 1)
+    transform-origin: left top
+    border: solid 1px
+
   .scroll-wrapper
     overflow: hidden
 


### PR DESCRIPTION
This fixes a long standing feature request from Dan - when the smaller linked interactive preview is clicked it is displayed in a larger area but the scaling stayed the same so it was very hard to read.  This also presented a problem during QA so I went ahead and fixed it (and it turned out it was a pretty easy fix)

Existing (unchanged preview selector):
![image](https://user-images.githubusercontent.com/112938/142426515-cf583a75-777f-4644-915e-5c588d79b51e.png)

Scaling **BEFORE** Fix
![image](https://user-images.githubusercontent.com/112938/142426856-5c9a7435-e0dc-43ff-9327-5f1976d8e095.png)

Scaling **AFTER** Fix (this PR)
![image](https://user-images.githubusercontent.com/112938/142426577-3691df0c-d4f1-4248-8013-5dba0e66674d.png)
