### PR TITLE
Send `requiresUserInteraction` event when putting up state selection dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-file-manager",
-  "version": "1.3.3",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2191,9 +2191,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -9310,16 +9310,6 @@
         "minipass": "^3.0.0"
       }
     },
-    "minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      }
-    },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -10309,9 +10299,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {
@@ -12318,14 +12308,12 @@
     },
     "tar": {
       "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.4.tgz",
-      "integrity": "sha512-kcPWrO8S5ABjuZ/v1xQHP8xCEvj1dQ1d9iAb6Qs4jLYzaAIYWwST2IQpz7Ud8VNYRI+fGhFjrnzRKmRggKWg3g==",
+      "resolved": "",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
         "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
       },
@@ -12483,9 +12471,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-arraybuffer": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.4.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/concord-consortium/cloud-file-manger"
+    "url": "https://github.com/concord-consortium/cloud-file-manager"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/concord-consortium/cloud-file-manger"

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1158,6 +1158,7 @@ class CloudFileManagerClient {
   }
 
   selectInteractiveStateDialog(props: SelectInteractiveStateDialogProps, callback: SelectInteractiveStateCallback): void {
+    this._event("requiresUserInteraction")
     this._ui.selectInteractiveStateDialog({...props, onSelect: callback})
   }
 

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -244,7 +244,7 @@ class InteractiveApiProvider extends ProviderInterface {
     return {interactiveState, interactiveId}
   }
 
-  getinteractiveId(initInteractiveMessage: IInitInteractive) {
+  getInteractiveId(initInteractiveMessage: IInitInteractive) {
     return initInteractiveMessage.mode === "runtime" ? initInteractiveMessage.interactive.id : undefined
   }
 
@@ -295,7 +295,7 @@ class InteractiveApiProvider extends ProviderInterface {
   async load(metadata: CloudMetadata, callback: ProviderLoadCallback) {
     const initInteractiveMessage = await this.getInitInteractiveMessage()
     try {
-      const interactiveId = this.getinteractiveId(initInteractiveMessage)
+      const interactiveId = this.getInteractiveId(initInteractiveMessage)
       const interactiveState = await this.processRawInteractiveState(await getInteractiveState(), interactiveId)
       // following the example of the LaraProvider, wrap the content in a CFM envelope
       const content = cloudContentFactory.createEnvelopedCloudContent(interactiveState)


### PR DESCRIPTION
[[#180401986]](https://www.pivotaltracker.com/story/show/180401986)

CODAP presents the splash screen but makes decisions about when to show/hide it based on event notifications from CFM. In this particular instance, CFM needs to show a dialog itself with which the CODAP splash screen interferes. Therefore, CFM sends the new `requiresUserInteraction` message when it needs to present a dialog during startup and in a separate [CODAP PR](https://github.com/concord-consortium/codap/pull/398), CODAP responds by hiding the splash screen when the CFM requires user interaction.

Also, increment the version number, fix a typo, and run `npm audit fix` while we're in the neighborhood.