### PR TITLE
Fix relative path of fonts

### DIFF
--- a/src/style/mixins/icons.styl
+++ b/src/style/mixins/icons.styl
@@ -1,10 +1,10 @@
 @font-face {
 	font-family: 'CodapIvy';
-	src:url('../fonts/CodapIvy.eot');
-	src:url('../fonts/CodapIvy.eot') format('embedded-opentype'),
-		url('../fonts/CodapIvy.ttf') format('truetype'),
-		url('../fonts/CodapIvy.woff') format('woff'),
-		url('../fonts/CodapIvy.svg') format('svg');
+	src:url('../../fonts/CodapIvy.eot');
+	src:url('../../fonts/CodapIvy.eot') format('embedded-opentype'),
+		url('../../fonts/CodapIvy.ttf') format('truetype'),
+		url('../../fonts/CodapIvy.woff') format('woff'),
+		url('../../fonts/CodapIvy.svg') format('svg');
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
Caused by the TypeScript conversion?

This fixes the CodapIvy font path which is used in the file dialogs.  This is what it looked like before the fix:

![image](https://user-images.githubusercontent.com/112938/147243372-3e38a2a5-26b9-4ab0-94b5-8889d44b6489.png)

and this is after the fix:

![image](https://user-images.githubusercontent.com/112938/147243498-b035a9b1-6143-4c81-96e7-57856db9b46c.png)
