### PR TITLE
[#180892247] Fix bug: icon font path broken for CODAP Build.

### DIFF
--- a/build-support/build-opts.js
+++ b/build-support/build-opts.js
@@ -34,7 +34,11 @@ const replacementStrings = {
 if (codap) {
   replacementStrings.css.push(
     {
-      search: /url\(..\/..\//g,
+      search: /url\("\.\.\//g,
+      replace: 'url("'
+    },
+    {
+      search: /url\(/g,
       replace: 'static_url('
     },
     {

--- a/build-support/build-opts.js
+++ b/build-support/build-opts.js
@@ -34,7 +34,7 @@ const replacementStrings = {
 if (codap) {
   replacementStrings.css.push(
     {
-      search: /url\(/g,
+      search: /url\(..\/..\//g,
       replace: 'static_url('
     },
     {


### PR DESCRIPTION
There was a recent adjustment to font paths for the Codap-Ivy icon font. Apparently this was to fix an error in the Sage build. It broke the references in the CODAP build. As far as I know, the only symbols actually used in the CODAP build are for file list icons in the Open/Save/... dialogs. Fixed the scripts for the CODAP build to restore the original paths.