### PR TITLE
Fix loss of file extension on rename after copy [#174494057]

### DIFF
--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -990,8 +990,7 @@ class CloudFileManagerClient {
         })
       } else {
         if (metadata) {
-          metadata.name = newName
-          metadata.filename = newName
+          metadata.rename(newName)
         } else {
           metadata = new CloudMetadata({
             name: newName,


### PR DESCRIPTION
This changes the code to use the newish rename method on the CloudMetadata class which handles setting the filename extension automatically.