### PR TITLE
Save query string on copy [#174494057]

### DIFF
--- a/src/code/client.test.ts
+++ b/src/code/client.test.ts
@@ -134,4 +134,52 @@ describe("CloudFileManagerClient", () => {
       })
     })
   })
+
+  describe("getCurrentUrl", () => {
+    let location: Location
+    let client: CloudFileManagerClient
+
+    beforeAll(() => {
+      location = window.location
+      delete window.location
+    })
+    beforeEach(() => {
+      client = new CloudFileManagerClient()
+    })
+    afterAll(() => {
+      window.location = location
+    })
+    test("without query or hash string", () => {
+      window.location = {
+        origin: "https://example.com",
+        pathname: "/foo",
+        search: ""
+      } as any
+      expect(client.getCurrentUrl()).toEqual("https://example.com/foo")
+    })
+    test("with query but no hash string", () => {
+      window.location = {
+        origin: "https://example.com",
+        pathname: "/foo",
+        search: "?bar=baz"
+      } as any
+      expect(client.getCurrentUrl()).toEqual("https://example.com/foo?bar=baz")
+    })
+    test("without query but with hash string", () => {
+      window.location = {
+        origin: "https://example.com",
+        pathname: "/foo",
+        search: ""
+      } as any
+      expect(client.getCurrentUrl("#bang=boom")).toEqual("https://example.com/foo#bang=boom")
+    })
+    test("with query and hash string", () => {
+      window.location = {
+        origin: "https://example.com",
+        pathname: "/foo",
+        search: "?bar=baz"
+      } as any
+      expect(client.getCurrentUrl("#bang=boom")).toEqual("https://example.com/foo?bar=baz#bang=boom")
+    })
+  })
 })

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1126,10 +1126,8 @@ class CloudFileManagerClient {
     return this._ui.hideBlockingModal()
   }
 
-  getCurrentUrl(queryString?: string) {
-    const suffix = (queryString != null) ? `?${queryString}` : ""
-    // Check browser support for document.location.origin (& window.location.origin)
-    return `${document.location.origin}${document.location.pathname}${suffix}`
+  getCurrentUrl(hashString?: string) {
+    return `${window.location.origin}${window.location.pathname}${window.location.search}${hashString || ""}`
   }
 
   // Takes an array of strings representing url parameters to be removed from the URL.


### PR DESCRIPTION
This fix is really for testing so that alternate cfm branches spec'ed in the query string are included in the copied tab.