### PR TITLE
Remove autosave of readonly providers in language switching [#175390295]

### DIFF
--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1110,7 +1110,7 @@ class CloudFileManagerClient {
           return callback(newLangCode)
         }
       }
-      if (this.state.metadata?.provider || this.autoProvider(ECapabilities.save)) {
+      if (this.state.metadata?.provider.can(ECapabilities.save)) {
         return this.save((err: string | null) => postSave(err))
       } else {
         return this.saveTempFile(postSave)


### PR DESCRIPTION
Before this change when an example file was loaded and then the language was changed a save dialog would be shown as the readonly provider can't save but there were other providers that could, eg Google Drive.

With this change the current provider saves only if it can, otherwise it falls back to saving a temp file in local storage.