### PR TITLE
Ensure document id in interactive api is not url encoded [#181103123]

### DIFF
--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -12,6 +12,8 @@ import {
   readAttachment, setInteractiveState as _setInteractiveState, writeAttachment
 } from '@concord-consortium/lara-interactive-api'
 import { SelectInteractiveStateDialogProps } from '../views/select-interactive-state-dialog-view'
+import { ensureDecodedParameter } from '../utils/ensure-decoded-parameter'
+
 const getInteractiveState = () => cloneDeep(_getInteractiveState())
 const setInteractiveState = <InteractiveState>(newState: InteractiveState | null) =>
         _setInteractiveState(cloneDeep(newState))
@@ -354,8 +356,10 @@ class InteractiveApiProvider extends ProviderInterface {
     }
     // otherwise, load the initial state from its document id (url)
     else if (openSavedParams.documentId) {
+      // documentId may be doubly (or more) encoded in the parameters
+      const documentId = ensureDecodedParameter(openSavedParams.documentId)
       try {
-        const response = await fetch(openSavedParams.documentId)
+        const response = await fetch(documentId)
         const interactiveState = response.ok ? await response.json() : undefined
         if (interactiveState) {
           // initialize our interactive state from the shared document contents
@@ -368,7 +372,7 @@ class InteractiveApiProvider extends ProviderInterface {
       catch(e) {
         // ignore errors
       }
-      callback(`Unable to open saved document: ${openSavedParams.documentId}!`)
+      callback(`Unable to open saved document: ${documentId}!`)
     }
     else {
       // in the absence of any provided content, initialize with an empty string

--- a/src/code/utils/ensure-decoded-parameter.test.ts
+++ b/src/code/utils/ensure-decoded-parameter.test.ts
@@ -1,0 +1,35 @@
+import { ensureDecodedParameter } from "./ensure-decoded-parameter"
+
+describe("ensureDecodedParameter", () => {
+  it("handles undefined strings", () => {
+    expect(ensureDecodedParameter()).toBeUndefined()
+  })
+
+  it("handles empty strings", () => {
+    expect(ensureDecodedParameter("")).toBe("")
+  })
+
+  it("handles non-encoded strings", () => {
+    expect(ensureDecodedParameter("foo")).toBe("foo")
+  })
+
+  it("handles single-encoded strings", () => {
+    expect(ensureDecodedParameter("this%20is%20a%20test")).toBe("this is a test")
+  })
+
+  it("handles double-encoded strings", () => {
+    expect(ensureDecodedParameter("this%2520is%2520a%2520test")).toBe("this is a test")
+  })
+
+  it("handles many, many encoded strings", () => {
+    for (let i = 3; i < 10; i++) {
+      const unencoded = "this is a test"
+      let encoded = unencoded
+      for (let j = 0; j < i; j++) {
+        encoded = encodeURIComponent(encoded)
+      }
+      expect(encoded).not.toEqual(unencoded)
+      expect(ensureDecodedParameter(encoded)).toBe(unencoded)
+    }
+  })
+})

--- a/src/code/utils/ensure-decoded-parameter.ts
+++ b/src/code/utils/ensure-decoded-parameter.ts
@@ -1,0 +1,10 @@
+const isEncoded = (value: string) => value !== decodeURIComponent(value)
+
+export const ensureDecodedParameter = (value?: string) => {
+  if (typeof value !== "undefined") {
+    while (isEncoded(value)){
+      value = decodeURIComponent(value)
+    }
+  }
+  return value
+}


### PR DESCRIPTION
Some of the question interactives have encoded CODAP/SageModeler urls that themselves have encoded document id urls.  This fix ensures the document id urls are fully decoded before they are fetched.