### PR TITLE
Added onUnload callback [#181169438]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -494,9 +494,9 @@
       "dev": true
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.3.0.tgz",
-      "integrity": "sha512-reNmLonA0qMzLND0Y1GhHqFdygOP0kDb4oHIWvktyJokzL/cNxOKjv60AlIIs55wm297i6DdFlvLSRR0VgNe6A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.5.2.tgz",
+      "integrity": "sha512-ITOMXtOfLfqusMuDSEgVQsv0HI7KdJ+GCtos9IjTDyvu5JdBKk6QLdHOB+bw4hfqKzpNnw8/ZjCaWllFLG7T+Q==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^1.3.0",
+    "@concord-consortium/lara-interactive-api": "^1.5.2",
     "@concord-consortium/token-service": "^2.0.0",
     "aws-sdk": "^2.958.0",
     "base64-js": "^1.5.1",

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -12,6 +12,7 @@ import {
   readAttachment, setInteractiveState as _setInteractiveState, writeAttachment
 } from '@concord-consortium/lara-interactive-api'
 import { SelectInteractiveStateDialogProps } from '../views/select-interactive-state-dialog-view'
+
 const getInteractiveState = () => cloneDeep(_getInteractiveState())
 const setInteractiveState = <InteractiveState>(newState: InteractiveState | null) =>
         _setInteractiveState(cloneDeep(newState))
@@ -161,7 +162,7 @@ class InteractiveApiProvider extends ProviderInterface {
   }
 
   async getInitialInteractiveStateAndinteractiveId(initInteractiveMessage: IInitInteractive): Promise<{interactiveState: {}, interactiveId?: string}> {
-    if (initInteractiveMessage.mode === "authoring") {
+    if ((initInteractiveMessage.mode === "authoring") || (initInteractiveMessage.mode === "reportItem")) {
       return null
     }
     if (initInteractiveMessage.mode === "report") {
@@ -309,23 +310,23 @@ class InteractiveApiProvider extends ProviderInterface {
   async save(cloudContent: any, metadata: CloudMetadata, callback?: ProviderSaveCallback, disablePatch?: boolean) {
     await this.getInitInteractiveMessage()
 
+    let savedContent: any
     const clientContent = cloudContent.getContent()
     const contentType = typeof clientContent === 'string' ? 'text/plain' : 'application/json'
     if (this.shouldSaveAsAttachment(clientContent)) {
       const content = contentType === 'application/json' ? JSON.stringify(clientContent) : clientContent
       const response = await writeAttachment({ name: kAttachmentFilename, content, contentType })
-      if (response.ok) {
-        setInteractiveState(interactiveStateAttachment(contentType))
-      }
-      else {
+      if (!response.ok) {
         // if write failed, pass error to callback
         return callback(response.statusText)
       }
+      savedContent = interactiveStateAttachment(contentType)
     }
     else {
-      setInteractiveState(clientContent)
+      savedContent = clientContent
     }
-    callback?.(null)
+    setInteractiveState(clientContent)
+    callback?.(null, 200, savedContent)
   }
 
   canOpenSaved() { return true }

--- a/src/code/providers/provider-interface.ts
+++ b/src/code/providers/provider-interface.ts
@@ -4,7 +4,7 @@ import _ from 'lodash'
 
 const FILE_EXTENSION_DELIMETER = "."
 
-export type ProviderSaveCallback = (err: string | null, statusCode?: number) => void;
+export type ProviderSaveCallback = (err: string | null, statusCode?: number, savedContent?: any) => void;
 
 export type ProviderOpenCallback = (err: string | null, content?: CloudContent, metadata?: CloudMetadata) => void
 export type ProviderLoadCallback = ProviderOpenCallback


### PR DESCRIPTION
This adds an `onUnload` callback that is triggered when Lara interactive API clients request the final interactive state when unloading from the page.  The initial use for this will be to get the final SageModeler/CODAP state from an interactive.