### PR TITLE
Change interactive member of init message optional [#181103123]

### DIFF
--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -170,13 +170,16 @@ class InteractiveApiProvider extends ProviderInterface {
     }
 
     let interactiveState = initInteractiveMessage.interactiveState
-    let interactiveId = initInteractiveMessage.interactive.id
+
+    // some interactives, like the full-screen wrapper always report they are in runtime
+    // mode, even when loaded in a report which does not define the interactive member
+    let interactiveId = initInteractiveMessage.interactive?.id
 
     const interactiveStateAvailable = !!interactiveState
     const {allLinkedStates} = initInteractiveMessage
 
     // this is adapted from the existing autolaunch.ts file
-    if (allLinkedStates?.length > 0) {
+    if (interactiveId && allLinkedStates?.length > 0) {
       // find linked state which is directly linked to this one along with the most recent linked state.
       const directlyLinkedState = allLinkedStates[0]
 


### PR DESCRIPTION
Some interactives, like the full-screen wrapper always report they are in runtime  mode, even when loaded in a report which does not define the interactive member.  This change makes the interactive member of the message optional.