### PR TITLE
Change interactive member of init message optional [#181103123] (Redo of PR #261 due to bad merge)

### DIFF
--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -171,13 +171,16 @@ class InteractiveApiProvider extends ProviderInterface {
     }
 
     let interactiveState = initInteractiveMessage.interactiveState
-    let interactiveId = initInteractiveMessage.interactive.id
+
+    // some interactives, like the full-screen wrapper always report they are in runtime
+    // mode, even when loaded in a report which does not define the interactive member
+    let interactiveId = initInteractiveMessage.interactive?.id
 
     const interactiveStateAvailable = !!interactiveState
     const {allLinkedStates} = initInteractiveMessage
 
     // this is adapted from the existing autolaunch.ts file
-    if (allLinkedStates?.length > 0) {
+    if (interactiveId && allLinkedStates?.length > 0) {
       // find linked state which is directly linked to this one along with the most recent linked state.
       const directlyLinkedState = allLinkedStates[0]
 


### PR DESCRIPTION
Some interactives, like the full-screen wrapper always report they are in runtime  mode, even when loaded in a report which does not define the interactive member.  This change makes the interactive member of the message optional.

*NOTE*: this is a redo of the branch used in this PR: https://github.com/concord-consortium/cloud-file-manager/pull/261/files.  It was merged into another PR branch but GitHub didn't change the base branch when the other branch was merged.