### PR TITLE
Added rewrite of sensor-interactive domain in interactive state links [#182916725]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -494,9 +494,9 @@
       "dev": true
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.5.2.tgz",
-      "integrity": "sha512-ITOMXtOfLfqusMuDSEgVQsv0HI7KdJ+GCtos9IjTDyvu5JdBKk6QLdHOB+bw4hfqKzpNnw8/ZjCaWllFLG7T+Q==",
+      "version": "1.7.1-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.7.1-pre.1.tgz",
+      "integrity": "sha512-CcmavcfccbULKCKfL4QNWv7drnxacCzvYuJnPi6aiIR+dQi3ksVGBvis3idIO2JDVZI7Gi0iWBmdsJtcxbWi+w==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,9 +494,9 @@
       "dev": true
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "1.7.1-pre.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.7.1-pre.1.tgz",
-      "integrity": "sha512-CcmavcfccbULKCKfL4QNWv7drnxacCzvYuJnPi6aiIR+dQi3ksVGBvis3idIO2JDVZI7Gi0iWBmdsJtcxbWi+w==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.7.1.tgz",
+      "integrity": "sha512-oiUYMG5qQYNxweDLJ6NKEGPSFF1n9GUeXlABUrI/pswEMwv0iRIlldJsprEhvlGcMZ3imRp8BUvZeVBiL58IXQ==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^1.5.2",
+    "@concord-consortium/lara-interactive-api": "^1.7.1-pre.1",
     "@concord-consortium/token-service": "^2.0.0",
     "aws-sdk": "^2.958.0",
     "base64-js": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^1.7.1-pre.1",
+    "@concord-consortium/lara-interactive-api": "^1.7.1",
     "@concord-consortium/token-service": "^2.0.0",
     "aws-sdk": "^2.958.0",
     "base64-js": "^1.5.1",

--- a/src/assets/examples/all-providers.html
+++ b/src/assets/examples/all-providers.html
@@ -18,6 +18,7 @@
         appName: "CFM_Demo",
         appVersion: "0.1",
         appBuildNum: "1",
+        iframeAllow: "geolocation; bluetooth",
         providers: [
           "localStorage",
           "localFile",

--- a/src/code/app-options.ts
+++ b/src/code/app-options.ts
@@ -126,4 +126,5 @@ export interface CFMAppOptions {
   usingIframe?: boolean;
   app?: string;   // required when iframing - relative path to the app to wrap
   contentSaveFilter?: ContentSaveFilterFn;
+  iframeAllow?: string;
 }

--- a/src/code/views/app-view.tsx
+++ b/src/code/views/app-view.tsx
@@ -52,7 +52,7 @@ const InnerApp = createReactClassFactory({
 
   render() {
     return (div({className: 'innerApp'},
-      (iframe({src: this.props.app}))
+      (iframe({src: this.props.app, allow: this.props.iframeAllow}))
     ))
   }
 })
@@ -65,6 +65,7 @@ interface IAppViewProps {
   enableLaraSharing?: boolean;
   usingIframe?: boolean;
   app?: string;   // src url for <iframe>
+  iframeAllow?: string;
 }
 
 interface IAppViewState {
@@ -302,7 +303,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
         (MenuBar({client: this.props.client, filename: this.state.filename, provider: this.state.provider, fileStatus: this.state.fileStatus, items: menuItems, options: this.state.menuOptions})),
         // only render the wrapped client app in app (iframe) mode
         this.props.usingIframe ?
-          (InnerApp({app: this.props.app})) : undefined,
+          (InnerApp({app: this.props.app, iframeAllow: this.props.iframeAllow})) : undefined,
         this.renderDialogs()
       ))
     } else if (this.state.providerDialog || this.state.downloadDialog) {


### PR DESCRIPTION
Also added `iframeAllow` client option so that SageModeler (and other apps that use CFMs wrapper) to inject `bluetooth` and other allowed features into the outer app iframe.