### PR TITLE
Added autosaving of directly linked state when there is no current state [#183903716]

### DIFF
--- a/src/code/providers/interactive-api-provider.test.ts
+++ b/src/code/providers/interactive-api-provider.test.ts
@@ -335,7 +335,9 @@ describe('InteractiveApiProvider', () => {
     expect(getMockedCall(clientListener, "openedFile").data.content).toEqual({foo: "test"})
     expect(mockFetch).not.toHaveBeenCalled()
     expect(mockApi.getInteractiveState).not.toHaveBeenCalled()
-    expect(mockApi.setInteractiveState).not.toHaveBeenCalled()
+
+    // check that the linked state is autosaved
+    expect(mockApi.setInteractiveState).toHaveBeenCalled()
   })
 
   it("uses interactive state if interactive state and linked state is provided", async () => {

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -264,6 +264,9 @@ class InteractiveApiProvider extends ProviderInterface {
       if (!interactiveStateAvailable && directlyLinkedState) {
         interactiveState = directlyLinkedState.interactiveState
         interactiveId = directlyLinkedState.interactive.id
+
+        // save the directly linked state so that it is available with the sharing plugin
+        await setInteractiveState(interactiveState)
       }
     }
 


### PR DESCRIPTION
Before this change if a student shared a Sage interactive which was displaying linked state instead of that question's interactive state (as the student had not made changes yet) the sharing plugin would show an empty document instead of the linked state seen by the student.  The sharing plugin uses the portal-report which uses the report initInteractive message which does not send linked interactive states as part of its message (only the runtime message does).  By autosaving the directly linked state when there is no current state the sharing plugin will now mirror what the student sees.