### PR TITLE
Treat empty object as empty content

### DIFF
--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -12,6 +12,7 @@ import {
   readAttachment, setInteractiveState as _setInteractiveState, writeAttachment, flushStateUpdates
 } from '@concord-consortium/lara-interactive-api'
 import { SelectInteractiveStateDialogProps } from '../views/select-interactive-state-dialog-view'
+import { isEmptyObject } from '../utils/is-empty-object'
 
 export const shouldSaveAsAttachment = (content: any) => {
   const interactiveApi = queryString.parse(location.search).interactiveApi
@@ -372,7 +373,10 @@ class InteractiveApiProvider extends ProviderInterface {
     }
 
     // if we have an initial state, then use it
-    if (initialInteractiveState != null) {
+    // under some circumstances (e.g. prior failure to save an attachment?), the
+    // initialInteractiveState is reported as an empty object, which is not considered
+    // valid for these purposes
+    if (initialInteractiveState != null && !isEmptyObject(initialInteractiveState)) {
       successCallback(this.rewriteInteractiveState(initialInteractiveState))
     }
     // otherwise, load the initial state from its document id (url)

--- a/src/code/utils/is-empty-object.ts
+++ b/src/code/utils/is-empty-object.ts
@@ -1,0 +1,3 @@
+import { isEmpty } from "lodash"
+
+export const isEmptyObject = (o: any) => typeof o === "object" && isEmpty(o)


### PR DESCRIPTION
PT: [[#183923855]](https://www.pivotaltracker.com/story/show/183923855)

Under some circumstances that we don't entirely understand, but seemingly involving a failure to save user content, the interactive state ends up being an empty object (`{}`), which is considered invalid by CODAP. Until we fix the underlying bug, we treat an empty object as null/empty content, which allows the authored content to be shown in the situation described by the PT story.