### PR TITLE
Fixed renaming with Google Drive provider [#183722341]

### DIFF
--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -321,10 +321,10 @@ class GoogleDriveProvider extends ProviderInterface {
 
   rename(metadata: CloudMetadata, newName: string, callback?: (err: string | null, metadata?: CloudMetadata) => void) {
     return this.waitForAPILoad().then(() => {
-      const request = gapi.client.drive.files.patch({
+      const request = gapi.client.drive.files.update({
         fileId: metadata.providerData.id,
         resource: {
-          title: CloudMetadata.withExtension(newName)
+          name: CloudMetadata.withExtension(newName)
         }
       })
       return request.execute((result: any) => {


### PR DESCRIPTION
Between v2 and v3 the client method changed from patch to update and the parameter changed from title to name.