### PR TITLE
Fix issue with CODAP file dialog buttons [#184137566]

### DIFF
--- a/src/code/views/file-dialog-tab-view.ts
+++ b/src/code/views/file-dialog-tab-view.ts
@@ -352,7 +352,7 @@ const FileDialogTab = createReactClass({
       ? div({}, `No files found matching "${this.state.filename}" in current folder`)
       : null
 
-    return (div({className: 'dialogTab'},
+    return (div({className: 'dialogTab fileDialog'},
       (input({type: 'text', value: this.state.filename, placeholder: (tr("~FILE_DIALOG.FILENAME")), onChange: this.filenameChanged, onKeyDown: this.watchForEnter, ref: (elt: any) => { return this.inputRef = elt }})),
       (listFiltered && div({className: 'dialogClearFilter', onClick: this.clearListFilter}, "X")),
       (FileList({provider: this.props.provider, folder: this.state.folder, selectedFile: this.state.metadata, fileSelected: this.fileSelected, fileConfirmed: this.confirm, list, listLoaded: this.listLoaded, client: this.props.client, overrideMessage})),

--- a/src/style/components/tabbed-panel.styl
+++ b/src/style/components/tabbed-panel.styl
@@ -93,3 +93,9 @@
           text-decoration none
         a.disabled
           background-color #777
+    .fileDialog
+      /* this is to fix an issue with CODAP due to the new filterable file listings */
+      .buttons
+        position absolute !important
+        bottom 10 !important
+        right 10 !important


### PR DESCRIPTION
This adds file dialog specific button styling to fix an issue with CODAP rendering the buttons outside the dialog due to its custom global navbar button css.

The issue is caused by the new filterable file listings.  As the height changes on the file list the buttons were not adjusting.