### PR TITLE
Removed LARA tab from sharing dialog [#184184524]

### DIFF
--- a/src/code/views/share-dialog-tabs-view.test.tsx
+++ b/src/code/views/share-dialog-tabs-view.test.tsx
@@ -22,7 +22,6 @@ describe('ShareDialogTabsView', () => {
     expect(screen.getByTestId('share-dialog-tabs-view')).toBeInTheDocument()
     expect(screen.getByTestId('sharing-tab-link')).toBeInTheDocument()
     expect(screen.getByTestId('sharing-tab-embed')).toBeInTheDocument()
-    expect(screen.queryByTestId('sharing-tab-lara')).toBeNull()
     expect(screen.queryByTestId('sharing-tab-api')).toBeNull()
     expect(screen.getByTestId('link-tab-contents')).toBeInTheDocument()
     expect(screen.queryByTestId('embed-tab-contents')).toBeNull()
@@ -45,7 +44,6 @@ describe('ShareDialogTabsView', () => {
     expect(screen.getByTestId('share-dialog-tabs-view')).toBeInTheDocument()
     expect(screen.getByTestId('sharing-tab-link')).toBeInTheDocument()
     expect(screen.getByTestId('sharing-tab-embed')).toBeInTheDocument()
-    expect(screen.queryByTestId('sharing-tab-lara')).toBeNull()
     expect(screen.queryByTestId('link-tab-contents')).toBeNull()
     expect(screen.getByTestId('embed-tab-contents')).toBeInTheDocument()
     expect(screen.queryByTestId('lara-api-tab-contents')).toBeNull()
@@ -67,56 +65,10 @@ describe('ShareDialogTabsView', () => {
     expect(screen.getByTestId('share-dialog-tabs-view')).toBeInTheDocument()
     expect(screen.getByTestId('sharing-tab-link')).toBeInTheDocument()
     expect(screen.getByTestId('sharing-tab-embed')).toBeInTheDocument()
-    expect(screen.queryByTestId('sharing-tab-lara')).toBeNull()
     expect(screen.queryByTestId('link-tab-contents')).toBeNull()
     expect(screen.queryByTestId('embed-tab-contents')).toBeNull()
     expect(screen.queryByTestId('lara-api-tab-contents')).toBeNull()
     expect(screen.queryByTestId('copy-anchor-link')).toBeNull()
-  })
-
-  it('renders with LARA sharing', async () => {
-    const mockSelectTab = jest.fn()
-    const mockCopy = jest.fn()
-    const mockChangeServerUrl = jest.fn()
-    const mockChangeFullscreenScaling = jest.fn()
-    const mockChangeVisibilityToggles = jest.fn()
-
-    // renders with the lara tab active
-    const laraTabProps: IShareDialogLaraApiTabProps = {
-      linkUrl: 'https:/concord.org/url',
-      serverUrlLabel: 'ServerUrl',
-      serverUrl: 'https://concord.org/server',
-      onChangeServerUrl: mockChangeServerUrl
-    }
-    render(
-      <ShareDialogTabsView tabSelected='lara' linkUrl='https://concord.org/link' embedUrl='https://concord.org/embed'
-        onSelectTab={mockSelectTab} onCopyClick={mockCopy} lara={laraTabProps}
-        fullscreenScaling={true} onChangeFullscreenScaling={mockChangeFullscreenScaling}
-        visibilityToggles={false} onChangeVisibilityToggles={mockChangeVisibilityToggles} />
-    )
-    expect(screen.getByTestId('share-dialog-tabs-view')).toBeInTheDocument()
-    expect(screen.getByTestId('sharing-tab-link')).toBeInTheDocument()
-    expect(screen.getByTestId('sharing-tab-embed')).toBeInTheDocument()
-    expect(screen.getByTestId('sharing-tab-lara')).toBeInTheDocument()
-    expect(screen.queryByTestId('link-tab-contents')).toBeNull()
-    expect(screen.queryByTestId('embed-tab-contents')).toBeNull()
-    expect(screen.getByTestId('lara-api-tab-contents')).toHaveClass('lara')
-
-    act(() => {
-      userEvent.click(screen.getByTestId('sharing-tab-lara'))
-    })
-    expect(mockSelectTab).toHaveBeenCalledTimes(1)
-    expect(mockSelectTab.mock.calls[0][0]).toBe('lara')
-
-    act(() => {
-      // trigger change handlers
-      fireEvent.change(screen.getByTestId('server-url-input'), { target: { value: 'https://concord.org/newServerUrl' } })
-      userEvent.click(screen.getByTestId('fullscreen-scaling-checkbox'))
-      userEvent.click(screen.getByTestId('visibility-toggles-checkbox'))
-    })
-    expect(mockChangeServerUrl).toHaveBeenCalled()
-    expect(mockChangeFullscreenScaling).toHaveBeenCalled()
-    expect(mockChangeVisibilityToggles).toHaveBeenCalled()
   })
 
   it('renders with interactive api sharing', async () => {
@@ -138,7 +90,6 @@ describe('ShareDialogTabsView', () => {
     expect(screen.getByTestId('share-dialog-tabs-view')).toBeInTheDocument()
     expect(screen.getByTestId('sharing-tab-link')).toBeInTheDocument()
     expect(screen.getByTestId('sharing-tab-embed')).toBeInTheDocument()
-    expect(screen.queryByTestId('sharing-tab-lara')).toBeNull()
     expect(screen.getByTestId('sharing-tab-api')).toBeInTheDocument()
     expect(screen.queryByTestId('link-tab-contents')).toBeNull()
     expect(screen.queryByTestId('embed-tab-contents')).toBeNull()

--- a/src/code/views/share-dialog-tabs-view.tsx
+++ b/src/code/views/share-dialog-tabs-view.tsx
@@ -142,7 +142,6 @@ interface IShareDialogTabsProps {
   tabSelected: ShareDialogTab;
   linkUrl: string;
   embedUrl: string;
-  lara?: IShareDialogLaraApiTabProps;
   interactiveApi?: IShareDialogLaraApiTabProps;
   fullscreenScaling?: boolean;
   visibilityToggles?: boolean;
@@ -152,7 +151,7 @@ interface IShareDialogTabsProps {
   onCopyClick: (e: React.MouseEvent) => void;
 }
 export const ShareDialogTabsView: React.FC<IShareDialogTabsProps> = ({
-              tabSelected, embedUrl, linkUrl, lara, interactiveApi, onSelectTab, onCopyClick, ...others
+              tabSelected, embedUrl, linkUrl, interactiveApi, onSelectTab, onCopyClick, ...others
 }) => {
   return (
     <div data-testid='share-dialog-tabs-view'>
@@ -165,11 +164,6 @@ export const ShareDialogTabsView: React.FC<IShareDialogTabsProps> = ({
             onClick={() => onSelectTab('embed')} data-testid='sharing-tab-embed'>
           {translate("~SHARE_DIALOG.EMBED_TAB")}
         </li>
-        {lara &&
-          <li className={classNames('sharing-tab', 'sharing-tab-lara', { 'sharing-tab-selected': tabSelected === 'lara' })}
-              onClick={() => onSelectTab('lara')} data-testid='sharing-tab-lara'>
-            LARA
-          </li>}
         {interactiveApi &&
           <li className={classNames('sharing-tab', 'sharing-tab-api', { 'sharing-tab-selected': tabSelected === 'api' })}
               onClick={() => onSelectTab('api')} data-testid='sharing-tab-api'>
@@ -183,11 +177,6 @@ export const ShareDialogTabsView: React.FC<IShareDialogTabsProps> = ({
               return <LinkTabContents url={linkUrl} onCopyClick={onCopyClick} />
             case 'embed':
               return <EmbedTabContents url={embedUrl} onCopyClick={onCopyClick} />
-            case 'lara': {
-              const { linkUrl: url, ...laraOthers } = lara
-              return <LaraApiTabContents mode='lara' linkUrl={url} onCopyClick={onCopyClick}
-                                        {...others} {...laraOthers} />
-            }
             case 'api': {
               const { linkUrl: url, ...apiOthers } = interactiveApi
               return <LaraApiTabContents mode='api' linkUrl={url} onCopyClick={onCopyClick}

--- a/src/code/views/share-dialog-view.test.tsx
+++ b/src/code/views/share-dialog-view.test.tsx
@@ -97,49 +97,6 @@ describe('ShareDialogView', () => {
     expect(screen.getByTestId('share-dialog')).toBeInTheDocument()
   })
 
-  it('should render shared with LARA', () => {
-    const mockAlert = jest.fn()
-    const mockToggleShare = jest.fn(callback => callback?.())
-    const mockUpdateShare = jest.fn()
-    const mockClose = jest.fn()
-
-    ;(window as any).clipboardData = {
-      getData: jest.fn(),
-      setData: jest.fn()
-    }
-
-    // render shared with LARA
-    const { rerender } = render(
-      <ShareDialogView currentBaseUrl='https://concord.org/baseUrl' isShared={true} enableLaraSharing={true}
-        sharedDocumentUrl='https://concord.org/sharedDocumentUrl'
-        onAlert={mockAlert} onToggleShare={mockToggleShare} onUpdateShare={mockUpdateShare} close={mockClose} />
-    )
-    expect(screen.getByTestId('share-dialog')).toBeInTheDocument()
-
-    act(() => {
-      userEvent.click(screen.getByTestId('sharing-tab-lara'))
-    })
-
-    rerender(
-      <ShareDialogView currentBaseUrl='https://concord.org/baseUrl' isShared={true} enableLaraSharing={true}
-        sharedDocumentUrl='https://concord.org/sharedDocumentUrl'
-        onAlert={mockAlert} onToggleShare={mockToggleShare} onUpdateShare={mockUpdateShare} close={mockClose} />
-    )
-
-    act(() => {
-      // copy LARA share url
-      userEvent.click(screen.getByTestId('copy-anchor-link'))
-    })
-
-    act(() => {
-      // trigger change handlers
-      fireEvent.change(screen.getByTestId('server-url-input'), { target: { value: 'https://concord.org/newServerUrl' } })
-      userEvent.click(screen.getByTestId('fullscreen-scaling-checkbox'))
-      userEvent.click(screen.getByTestId('visibility-toggles-checkbox'))
-    })
-  })
-
-
   it('should render shared with interactive api sharing', () => {
     const mockAlert = jest.fn()
     const mockToggleShare = jest.fn(callback => callback?.())

--- a/src/code/views/share-dialog-view.tsx
+++ b/src/code/views/share-dialog-view.tsx
@@ -257,14 +257,6 @@ export default class ShareDialogView extends React.Component<IShareDialogProps, 
               tabSelected={this.state.tabSelected}
               linkUrl={this.state.link}
               embedUrl={this.state.embed}
-              lara={this.props.enableLaraSharing
-                ? {
-                    linkUrl: this.getLara(),
-                    serverUrlLabel: this.state.laraServerUrlLabel,
-                    serverUrl: this.state.laraServerUrl,
-                    onChangeServerUrl: this.changedLaraServerUrl
-                  }
-                : undefined}
               interactiveApi={this.props.enableLaraSharing
                 ? {
                     linkUrl: this.getInteractiveApiLink(),

--- a/src/code/views/share-loading-view.tsx
+++ b/src/code/views/share-loading-view.tsx
@@ -4,7 +4,7 @@ import { Spinner } from './icons/spin'
 
 export const ShareLoadingView = (props: {}) => {
   return (
-    <div data-testid='share-loading-view'>
+    <div className='share-loading-view' data-testid='share-loading-view'>
       <Spinner fill="gray" size={100}/>
       {translate("~SHARE_DIALOG.PLEASE_WAIT")}
     </div>

--- a/src/style/components/share-loading-view.styl
+++ b/src/style/components/share-loading-view.styl
@@ -1,0 +1,10 @@
+.share-loading-view
+  display flex
+  flex-direction row
+  gap 5px
+  align-content center
+  justify-content center
+
+  svg
+    width 16px
+    height 16px


### PR DESCRIPTION
Also fixed long standing css issues with the share loading dialog:

1. Set svg loading spinner size to 16px x 16px
2. Centered the spinner and text both horizontally and vertically in dialog