### PR TITLE
Fixed blank parent folder when showing open dialog the second time [#184192561]

### DIFF
--- a/src/code/views/file-dialog-tab-view.ts
+++ b/src/code/views/file-dialog-tab-view.ts
@@ -241,7 +241,7 @@ const FileDialogTab = createReactClass({
   getStateForFolder(folder: CloudMetadata, initialFolder: any) {
     const metadata = this.isOpen() ? this.state?.metadata || null : this.getSaveMetadata()
 
-    if (initialFolder && (this.props.client.state.metadata?.provider !== this.props.provider)) {
+    if (initialFolder || (this.props.client.state.metadata?.provider !== this.props.provider)) {
       folder = null
     } else {
       if (metadata != null) {


### PR DESCRIPTION
The logic should have been: is this the initial folder or has the provider changed and instead it was is this the initial folder and has the provider changed.