### PR TITLE
Added better read-only support [#180756824]

### DIFF
--- a/src/code/client.test.ts
+++ b/src/code/client.test.ts
@@ -102,7 +102,8 @@ describe("CloudFileManagerClient", () => {
       // to set the current metadata in order to fake the file already having been loaded
       client._setState({metadata: {
         name: "foo.txt",
-        provider: testProvider
+        provider: testProvider,
+        overwritable: true
       } as any})
 
       // initial save works without filtering

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -644,8 +644,11 @@ class CloudFileManagerClient {
   }
 
   saveFile(stringContent: any, metadata: CloudMetadata, callback: OpenSaveCallback = null) {
+    const readonly = metadata && !metadata.overwritable // only check if metadata exists
+    const resaveable = metadata?.provider?.can(ECapabilities.resave, metadata)
+
     // must be able to 'resave' to save silently, i.e. without save dialog
-    if (metadata?.provider?.can(ECapabilities.resave, metadata)) {
+    if (!readonly && resaveable) {
       return this.saveFileNoDialog(stringContent, metadata, callback)
     } else {
       return this.saveFileDialog(stringContent, callback)

--- a/src/code/providers/provider-interface.ts
+++ b/src/code/providers/provider-interface.ts
@@ -91,7 +91,7 @@ class CloudMetadata {
     this.parent = parent
     providerData = options.providerData
     this.providerData = providerData != null ? providerData : {}
-    this.overwritable = options.overwritable
+    this.overwritable = options.hasOwnProperty("overwritable") ? options.overwritable : true // default to true for overwritable
     this.sharedContentId = options.sharedContentId
     this.sharedContentSecretKey = options.sharedContentSecretKey
     this.mimeType = options.mimeType


### PR DESCRIPTION
Instead of showing a save error on readonly shared Google drive files the save dialog is always shown on saves.