### PR TITLE
fix: :bug: Removed changed client provider check in file dialog tab

### DIFF
--- a/src/code/views/file-dialog-tab-view.ts
+++ b/src/code/views/file-dialog-tab-view.ts
@@ -266,9 +266,8 @@ const FileDialogTab = createReactClass({
 
   getStateForFolder(folder: CloudMetadata, initialFolder: any) {
     const metadata = this.isOpen() ? this.state?.metadata || null : this.getSaveMetadata()
-    const clientProvider = this.props.client.state.metadata?.provider
 
-    if (initialFolder || (clientProvider && (clientProvider !== this.props.provider))) {
+    if (initialFolder) {
       folder = null
     } else {
       if (metadata != null) {


### PR DESCRIPTION
This prevented a file opened in the readonly provider from being saved in the google provider