### PR TITLE
Remove extension from local file save [#184486444]

### DIFF
--- a/src/code/views/local-file-tab-save-view.ts
+++ b/src/code/views/local-file-tab-save-view.ts
@@ -29,8 +29,7 @@ export default createReactClass({
     const hasPropsContent = ((this.props.dialog.data != null ? this.props.dialog.data.content : undefined) != null)
     const extension = hasPropsContent && this.props.dialog.data.extension
                   ? this.props.dialog.data.extension : 'json'
-    let filename = (this.props.client.state.metadata != null ? this.props.client.state.metadata.name : undefined) || (tr("~MENUBAR.UNTITLED_DOCUMENT"))
-    filename = CloudMetadata.newExtension(filename, extension)
+    const filename = (this.props.client.state.metadata != null ? this.props.client.state.metadata.name : undefined) || (tr("~MENUBAR.UNTITLED_DOCUMENT"))
 
     return {
       filename,


### PR DESCRIPTION
This fixes a recent change made when adding extensions to the export dialog.  The export dialog still has the extension but the local file save no longer does (as requested).