### PR TITLE
chore: Add "engines" to package.json (fixes GH-112 & PT-185071892)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "type": "git",
     "url": "https://github.com/concord-consortium/cloud-file-manager"
   },
+  "engines": {
+    "node": ">= 16",
+    "npm": ">= 8"
+  },
+  "engineStrict": true,
   "license": "MIT",
   "dependencies": {
     "@concord-consortium/lara-interactive-api": "^1.7.1",


### PR DESCRIPTION
Only allow using Node.js `>= 16` since we use Node.js v16 with Travis: https://github.com/concord-consortium/cloud-file-manager/blob/1daeff6cdf248e0b379328704748b0862e623898/.travis.yml#L4-L5