### PR TITLE
chore(npm): Add 'engine-strict' to project config (PT-185071892)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "node": ">= 16",
     "npm": ">= 8"
   },
-  "engineStrict": true,
   "license": "MIT",
   "dependencies": {
     "@concord-consortium/lara-interactive-api": "^1.7.1",


### PR DESCRIPTION
"engineStrict" in 'package.json' is deprecated, see https://github.com/concord-consortium/codap/pull/786#pullrequestreview-1414210977