### PR TITLE
fix: Missing broadcast of logLaraData from interactive-api-provider [PT-184770212]

### DIFF
--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1025,7 +1025,7 @@ class CloudFileManagerClient {
 
       const done = () => typeof callback === 'function' ? callback(newName) : undefined
 
-      const readOnlyProvider = metadata?.provider?.name === ReadOnlyProvider.Name;
+      const readOnlyProvider = metadata?.provider?.name === ReadOnlyProvider.Name
       if (!readOnlyProvider && (metadata?.provider || this.autoProvider(ECapabilities.save))) {
         // autosave renamed file if it has already been saved or can be autosaved
         this.save(done)

--- a/src/code/providers/interactive-api-provider.test.ts
+++ b/src/code/providers/interactive-api-provider.test.ts
@@ -182,10 +182,12 @@ describe('InteractiveApiProvider', () => {
     const mockLogLaraData = jest.fn()
 
     const client = new CloudFileManagerClient()
+    // set the app options to null as the interactive api provider checks it for the logging setup
+    client.setAppOptions(null)
     const provider = new InteractiveApiProvider({ logLaraData: mockLogLaraData }, client)
     await provider.isReady()
     expect(provider.name).toBe(InteractiveApiProvider.Name)
-    expect(mockApi.getInitInteractiveMessage).toHaveBeenCalledTimes(1)
+    expect(mockApi.getInitInteractiveMessage).toHaveBeenCalledTimes(2)
     expect(mockFetch).not.toHaveBeenCalled()
     expect(mockLogLaraData).toHaveBeenCalledTimes(1)
     // client-provided logLaraData should be called with run_remote_endpoint

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -127,6 +127,9 @@ class InteractiveApiProvider extends ProviderInterface {
       }
       // pass the LARA info (notably the run_remote_endpoint) to the CFM client
       this.options?.logLaraData?.(laraData)
+
+      // broadcast the log event
+      this.client.log('logLaraData', laraData)
     }
   }
 


### PR DESCRIPTION
This was causing CODAP to not log the run_remote_endpoint when it logged messages.