### PR TITLE
chore: update comments and ReadMe; eliminate more semicolons for consistency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,10 @@
     "dot-notation": ["off", { "allowKeywords": false }],
     "@typescript-eslint/dot-notation": ["warn", { "allowKeywords": false }],
     "eqeqeq": ["error", "allow-null"],
+    "@typescript-eslint/member-delimiter-style": ["warn", {
+      "multiline": { "delimiter": "none" },
+      "singleline": { "delimiter": "comma" }
+    }],
     "no-alert": "error",
     "no-caller": "error",
     "no-eval": "error",
@@ -90,7 +94,8 @@
     "no-whitespace-before-property": "warn",
     "quote-props": ["error", "as-needed", { "keywords": true, "unnecessary": false }],
     "quotes": "off",
-    "semi": ["warn", "never"],
+    "semi": "off",
+    "@typescript-eslint/semi": ["warn", "never"],
     "react/display-name": "off",
     "react/prop-types": "off", // TODO: FIX THIS
     "react/no-find-dom-node": "off" // TODO: Fix this!!!

--- a/src/code/app-options.ts
+++ b/src/code/app-options.ts
@@ -2,99 +2,99 @@ import React from "react"
 import { CloudContent } from "./providers/provider-interface"
 
 export interface CFMMenuItemObject {
-  name?: string;
-  key?: string;
-  action?: string | (() => void);
-  items?: CFMMenuItem[];
-  enabled?: boolean | (() => boolean);
-  separator?: boolean;
+  name?: string
+  key?: string
+  action?: string | (() => void)
+  items?: CFMMenuItem[]
+  enabled?: boolean | (() => boolean)
+  separator?: boolean
 }
 
-export type CFMMenuItem = string | CFMMenuItemObject;
+export type CFMMenuItem = string | CFMMenuItemObject
 
-export type CFMMenu = CFMMenuItem[];
+export type CFMMenu = CFMMenuItem[]
 
 export interface CFMMenuBarOptions {
-  info?: string;
+  info?: string
   languageMenu?: {
-    currentLang: string;
-    options: { label: string, langCode: string }[];
-  };
-  onLangChanged?: (langCode: string) => void;
+    currentLang: string
+    options: { label: string, langCode: string }[]
+  }
+  onLangChanged?: (langCode: string) => void
 }
 
 export interface CFMShareDialogSettings {
-  serverUrl?: string;
-  serverUrlLabel?: string;
+  serverUrl?: string
+  serverUrlLabel?: string
 }
 
 export interface CFMUIOptions {
-  menuBar?: CFMMenuBarOptions;
-  menu?: CFMMenu | null;                // null => no menu; undefined => default menu
-  menuNames?: Record<string, string>;   // map from menu item string to menu display name for string-only menu items
-  windowTitleSuffix?: string;
-  windowTitleSeparator?: string;
-  newFileOpensInNewTab?: boolean;
-  newFileAddsNewToQuery?: boolean;
-  confirmCloseIfDirty?: boolean;
-  shareDialog?: CFMShareDialogSettings;
+  menuBar?: CFMMenuBarOptions
+  // null => no menu; undefined => default menu
+  menu?: CFMMenu | null
+  // map from menu item string to menu display name for string-only menu items
+  menuNames?: Record<string, string>
+  // used for setting the page title from the document name (see appSetsWindowTitle)
+  windowTitleSuffix?: string
+  windowTitleSeparator?: string
+  newFileOpensInNewTab?: boolean
+  newFileAddsNewToQuery?: boolean
+  // if true, adds `beforeunload` handler to request confirmation before leaving page
+  confirmCloseIfDirty?: boolean
+  shareDialog?: CFMShareDialogSettings
 }
 
 export interface CFMBaseProviderOptions {
-  name?: string;
-  displayName?: string;
-  urlDisplayName?: string;
-  mimeType?: string;
+  name?: string
+  displayName?: string
+  urlDisplayName?: string
+  mimeType?: string
   // note different capitalization from CFMAppOptions
-  readableMimetypes?: string[];
+  readableMimetypes?: string[]
 }
 
 export interface CFMReadOnlyProviderOptions extends CFMBaseProviderOptions {
-  src: string;
-  alphabetize: boolean;
-  json: any;
-  jsonCallback: (callback: (err: string | null, json: any) => void) => void;
+  src: string
+  alphabetize: boolean
+  json: any
+  jsonCallback: (callback: (err: string | null, json: any) => void) => void
 }
 
 export interface CFMPatchProviderOptions extends CFMBaseProviderOptions {
-  patch?: boolean;
-  patchObjectHash?: (obj: any) => string;
+  patch?: boolean
+  patchObjectHash?: (obj: any) => string
 }
 
 export interface CFMLaraProviderLogData {
-  operation: string;
-  documentID?: string;
-  documentUrl?: string;
-  runStateUrl?: string;
-  run_remote_endpoint?: string;
-  collaboratorUrls?: string[];
+  operation: string
+  documentID?: string
+  documentUrl?: string
+  runStateUrl?: string
+  run_remote_endpoint?: string
+  collaboratorUrls?: string[]
 }
 
 export interface CFMLaraProviderOptions extends CFMPatchProviderOptions {
-  logLaraData?: (laraData: CFMLaraProviderLogData) => void;
+  logLaraData?: (laraData: CFMLaraProviderLogData) => void
 }
 
 export interface CFMDocumentStoreProviderOptions extends CFMPatchProviderOptions {
-  deprecationPhase: number;
+  deprecationPhase: number
 }
 
 export interface CFMLegacyGoogleDriveProviderOptions extends CFMBaseProviderOptions {
-  clientId: string;
-  apiKey: string;
-  scopes?: string[];
-  disableSharedDrives?: boolean;
+  clientId: string
+  apiKey: string
+  scopes?: string[]
+  disableSharedDrives?: boolean
 }
 
-export interface CFMGoogleDriveProviderOptions extends CFMBaseProviderOptions {
-  clientId: string;
-  apiKey: string;
-  appId: string;
-  scopes?: string[];
-  disableSharedDrives?: boolean;
+export interface CFMGoogleDriveProviderOptions extends CFMLegacyGoogleDriveProviderOptions {
+  appId: string
 }
 
 export interface CFMCustomClientProviderOptions extends CFMBaseProviderOptions {
-  createProvider: (providerBase: any) => any;
+  createProvider: (providerBase: any) => any
 }
 
 export const isCustomClientProvider = (options: CFMProviderOptions): options is CFMCustomClientProviderOptions =>
@@ -102,42 +102,56 @@ export const isCustomClientProvider = (options: CFMProviderOptions): options is 
 
 export type CFMProviderOptions = CFMBaseProviderOptions | CFMReadOnlyProviderOptions | CFMLaraProviderOptions |
                                 CFMDocumentStoreProviderOptions | CFMGoogleDriveProviderOptions |
-                                CFMCustomClientProviderOptions;
+                                CFMCustomClientProviderOptions
 
-export type ContentLoadFilterFn = (clientContent: CloudContent) => any;
-export type ContentSaveFilterFn = (clientContent: CloudContent) => any;
+export type ContentLoadFilterFn = (clientContent: CloudContent) => any
+export type ContentSaveFilterFn = (clientContent: CloudContent) => any
 
 export interface CFMHashParams {
-  sharedContentId?: string;
-  fileParams?: string;
-  copyParams?: string;
-  newInFolderParams?: string;
+  sharedContentId?: string
+  fileParams?: string
+  copyParams?: string
+  newInFolderParams?: string
 }
 
 export interface CFMAppOptions {
-  autoSaveInterval?: number;
-  appName?: string;
-  appVersion?: string;
-  appBuildNum?: string;
-  appOrMenuElemId?: string;
-  hideMenuBar?: boolean;
-  ui?: CFMUIOptions;
-  appSetsWindowTitle?: boolean;
-  wrapFileContent?: boolean;
-  mimeType?: string;
+  // seconds (or milliseconds if > 1000), auto-save disabled by default
+  autoSaveInterval?: number
+  appName?: string
+  appVersion?: string
+  appBuildNum?: string
+  // If appOrMenuElemId is set and usingIframe is true, then the CFM presents
+  // its UI and the wrapped client app within the specified element.
+  // If appOrMenuElemId is set and usingIframe is false, then the CFM presents its menubar
+  // UI within the specified element, but there is no iframe or wrapped client app.
+  appOrMenuElemId?: string
+  // true if the menu bar should be hidden, false (default) otherwise
+  hideMenuBar?: boolean
+  ui?: CFMUIOptions
+  // true if the application sets the page title
+  // false (default) if CFM sets page title from document name
+  appSetsWindowTitle?: boolean
+  wrapFileContent?: boolean
+  mimeType?: string
   // note different capitalization from CFMBaseProviderOptions
-  readableMimeTypes?: string[];
-  extension?: string;
-  readableExtensions?: string[];
-  enableLaraSharing?: boolean;
-  log?: (event: string, eventData: any) => void;
-  providers?: (CFMProviderOptions | string)[];
-  hashParams?: CFMHashParams;
-  sendPostMessageClientEvents?: boolean;
-  usingIframe?: boolean;
-  app?: string;   // required when iframing - relative path to the app to wrap
-  contentLoadFilter?: ContentLoadFilterFn;
-  contentSaveFilter?: ContentSaveFilterFn;
+  readableMimeTypes?: string[]
+  extension?: string
+  readableExtensions?: string[]
+  enableLaraSharing?: boolean
+  log?: (event: string, eventData: any) => void
+  providers?: (CFMProviderOptions | string)[]
+  hashParams?: CFMHashParams
+  sendPostMessageClientEvents?: boolean
+  // if true, client app is wrapped in an iframe within the CFM-managed div
+  usingIframe?: boolean
+  // required when iframing - relative path to the app to wrap
+  app?: string
+  // called to preprocess content when loading files
+  contentLoadFilter?: ContentLoadFilterFn
+  // called to preprocess content when saving files
+  contentSaveFilter?: ContentSaveFilterFn
+  // allow clients to customize rendering, e.g. for React 18
   renderRoot?: (content: React.ReactNode, container: HTMLElement) => void
-  iframeAllow?: string;
+  // when usingIframe, specifies the `allow` property of the iframe (permissions policy)
+  iframeAllow?: string
 }

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -42,20 +42,20 @@ let CLOUDFILEMANAGER_EVENT_ID = 0
 const CLOUDFILEMANAGER_EVENTS: Record<number, CloudFileManagerClientEvent> = {}
 
 interface IClientState {
-  availableProviders: any[];
-  shareProvider?: any;
-  openedContent?: any;
-  currentContent?: any;
-  metadata?: CloudMetadata;
-  saving?: CloudMetadata | null;
-  saved?: boolean;
-  sharing?: boolean;
-  dirty?: boolean;
-  failures?: number;
-  showingSaveAlert?: boolean;
+  availableProviders: any[]
+  shareProvider?: any
+  openedContent?: any
+  currentContent?: any
+  metadata?: CloudMetadata
+  saving?: CloudMetadata | null
+  saved?: boolean
+  sharing?: boolean
+  dirty?: boolean
+  failures?: number
+  showingSaveAlert?: boolean
 }
 
-export type ClientEventCallback = (...args: any) => void;
+export type ClientEventCallback = (...args: any) => void
 
 
 class CloudFileManagerClientEvent {
@@ -88,8 +88,8 @@ class CloudFileManagerClientEvent {
   }
 }
 
-export type ClientEventListener = (event: CloudFileManagerClientEvent) => void;
-export type OpenSaveCallback = (content: any, metadata: CloudMetadata, savedContent?: any) => void;
+export type ClientEventListener = (event: CloudFileManagerClientEvent) => void
+export type OpenSaveCallback = (content: any, metadata: CloudMetadata, savedContent?: any) => void
 
 class CloudFileManagerClient {
   _autoSaveInterval: number
@@ -103,7 +103,7 @@ class CloudFileManagerClient {
   state: IClientState
   urlProvider: URLProvider
   connectedPromise: Promise<void>
-  connectedPromiseResolver: { resolve: () => void; reject: () => void }
+  connectedPromiseResolver: { resolve: () => void, reject: () => void }
 
   constructor(options?: any) {
     this.shouldAutoSave = this.shouldAutoSave.bind(this)
@@ -139,7 +139,7 @@ class CloudFileManagerClient {
     if (this.appOptions.wrapFileContent == null) { this.appOptions.wrapFileContent = true }
     CloudContent.wrapFileContent = this.appOptions.wrapFileContent
 
-    type ProviderClass = any;
+    type ProviderClass = any
     const allProviders: Record<string, ProviderClass> = {}
 
     // Determine the available providers. Note that order in the list can

--- a/src/code/providers/document-store-provider.ts
+++ b/src/code/providers/document-store-provider.ts
@@ -334,7 +334,7 @@ class DocumentStoreProvider extends ProviderInterface {
   load(metadata: CloudMetadata, callback: (err: string | null, data?: any) => void) {
     const withCredentials = !metadata.sharedContentId
     const recordid = (metadata.providerData != null ? metadata.providerData.id : undefined) || metadata.sharedContentId
-    const requestData: { recordid?: string; runKey?: string; recordname?: string; owner?: string; } = {}
+    const requestData: { recordid?: string, runKey?: string, recordname?: string, owner?: string } = {}
     if (recordid) { requestData.recordid = recordid }
     if (this.urlParams.runKey) { requestData.runKey = this.urlParams.runKey }
     if (!recordid) {

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -53,8 +53,8 @@ export const setInteractiveState = async (_newState: any): Promise<{error: strin
 }
 
 interface InteractiveApiProviderParams {
-  documentId?: string;
-  interactiveState?: any;
+  documentId?: string
+  interactiveState?: any
 }
 
 // pass `interactiveApi=attachment` as url parameter to always save state as an attachment
@@ -68,7 +68,7 @@ export const kAttachmentFilename = "file.json"
 
 // when writing attachments, interactive state is just a reference to the attachment
 interface InteractiveStateAttachment {
-  __attachment__: typeof kAttachmentFilename,
+  __attachment__: typeof kAttachmentFilename
   contentType?: "application/json" | "text/plain"
 }
 const interactiveStateAttachment =

--- a/src/code/providers/lara-provider.ts
+++ b/src/code/providers/lara-provider.ts
@@ -30,34 +30,34 @@ import _ from 'lodash'
 // places users can choose to open/save files like Google Drive does.
 
 interface LaraProviderOpenSavedParams {
-  recordid?: string;
-  url: string;
-  source: string;
-  readOnlyKey: string;
-  collaboratorUrls?: string[];
+  recordid?: string
+  url: string
+  source: string
+  readOnlyKey: string
+  collaboratorUrls?: string[]
 }
 
 interface LaraProviderUrlParams {
-  documentServer?: string;
-  launchFromLara?: string;
+  documentServer?: string
+  launchFromLara?: string
 }
 
 interface LaraProviderLaraParams {
-  url?: string;
-  source?: string;
+  url?: string
+  source?: string
 }
 
 interface LaraProviderCreateResponse {
-  id: string;
-  readAccessKey: string;
-  readWriteAccessKey: string;
+  id: string
+  readAccessKey: string
+  readWriteAccessKey: string
 }
 
 interface LaraProviderDocStoreParams {
-  recordid?: string;
+  recordid?: string
   accessKeys?: {
-    readOnly?: string;
-    readWrite?: string;
+    readOnly?: string
+    readWrite?: string
   }
   collaborator?: 'leader' | 'follower'
 }

--- a/src/code/providers/provider-interface.ts
+++ b/src/code/providers/provider-interface.ts
@@ -4,14 +4,14 @@ import _ from 'lodash'
 
 const FILE_EXTENSION_DELIMETER = "."
 
-export type ProviderSaveCallback = (err: string | null, statusCode?: number, savedContent?: any) => void;
+export type ProviderSaveCallback = (err: string | null, statusCode?: number, savedContent?: any) => void
 
 export type ProviderOpenCallback = (err: string | null, content?: CloudContent, metadata?: CloudMetadata) => void
 export type ProviderLoadCallback = ProviderOpenCallback
 
 export type ProviderListCallback = (err: string | null, list?: CloudMetadata[]) => void
 
-export type ProviderRenameCallback = (err: string | null, metadata?: CloudMetadata) => void;
+export type ProviderRenameCallback = (err: string | null, metadata?: CloudMetadata) => void
 
 export type ProviderRemoveCallback = (err: string) => void
 
@@ -29,8 +29,8 @@ export enum ICloudFileTypes {
 
 type CloudFileContentType = string
 interface ICloudFileOpts {
-  content: CloudFileContentType;
-  metadata: CloudMetadata;
+  content: CloudFileContentType
+  metadata: CloudMetadata
 }
 
 class CloudFile {
@@ -367,10 +367,10 @@ type IProviderCapabilities = {
 export type AuthorizedOptions = {forceAuthorization?: boolean}
 
 export interface IProviderInterfaceOpts {
-  name: string;             // name by which it is referenced internally
-  displayName?: string;     // name which is displayed to users
-  urlDisplayName?: string;  // name that is used for url parameter matching
-  capabilities: IProviderCapabilities;
+  name: string             // name by which it is referenced internally
+  displayName?: string     // name which is displayed to users
+  urlDisplayName?: string  // name that is used for url parameter matching
+  capabilities: IProviderCapabilities
 }
 
 export interface IListOptions {

--- a/src/code/providers/url-provider.test.ts
+++ b/src/code/providers/url-provider.test.ts
@@ -5,9 +5,9 @@ import URLProvider from './url-provider'
 
 describe('URLProvider', () => {
   interface IAjaxOptions {
-    url: string;
-    success: (data: any) => void;
-    error: () => void;
+    url: string
+    success: (data: any) => void
+    error: () => void
   }
   const successUrl = 'https://concord.org/successUrl'
   const successResponse = 'Success!'

--- a/src/code/ui.ts
+++ b/src/code/ui.ts
@@ -126,8 +126,8 @@ class CloudFileManagerUIMenu {
   }
 }
 
-export type UIEventCallback = (...args: any) => void;
-export type UIEventListenerCallback = (event: CloudFileManagerUIEvent) => void;
+export type UIEventCallback = (...args: any) => void
+export type UIEventListenerCallback = (event: CloudFileManagerUIEvent) => void
 
 class CloudFileManagerUI {
   client: CloudFileManagerClient

--- a/src/code/utils/translate.ts
+++ b/src/code/utils/translate.ts
@@ -27,8 +27,8 @@ import zhTW from './lang/zh-TW.json'
 
 type LanguageFileContent = Record<string, string>
 interface LanguageFileEntry {
-  key: string;
-  contents: LanguageFileContent;
+  key: string
+  contents: LanguageFileContent
 }
 
 const languageFiles: LanguageFileEntry[] = [

--- a/src/code/views/app-view.tsx
+++ b/src/code/views/app-view.tsx
@@ -58,32 +58,32 @@ const InnerApp = createReactClassFactory({
 })
 
 interface IAppViewProps {
-  client?: CloudFileManagerClient;
-  ui?: CFMUIOptions;
-  appOrMenuElemId?: string;
-  hideMenuBar?: boolean;
-  enableLaraSharing?: boolean;
-  usingIframe?: boolean;
-  app?: string;   // src url for <iframe>
-  iframeAllow?: string;
+  client?: CloudFileManagerClient
+  ui?: CFMUIOptions
+  appOrMenuElemId?: string
+  hideMenuBar?: boolean
+  enableLaraSharing?: boolean
+  usingIframe?: boolean
+  app?: string   // src url for <iframe>
+  iframeAllow?: string
 }
 
 interface IAppViewState {
-  filename: string | null;
-  provider?: any;
-  menuItems: CFMMenuItem[];
-  menuOptions: CFMMenuBarOptions;
-  providerDialog: null | Record<string, any>;
-  downloadDialog: null | Record<string, any>;
-  renameDialog: null | Record<string, any>;
-  shareDialog: null | CFMShareDialogSettings;
-  blockingModalProps: null | Record<string, any>;
-  alertDialog: null | Record<string, any>;
-  confirmDialog: null | Record<string, any>;
-  importDialog: null | Record<string, any>;
+  filename: string | null
+  provider?: any
+  menuItems: CFMMenuItem[]
+  menuOptions: CFMMenuBarOptions
+  providerDialog: null | Record<string, any>
+  downloadDialog: null | Record<string, any>
+  renameDialog: null | Record<string, any>
+  shareDialog: null | CFMShareDialogSettings
+  blockingModalProps: null | Record<string, any>
+  alertDialog: null | Record<string, any>
+  confirmDialog: null | Record<string, any>
+  importDialog: null | Record<string, any>
   selectInteractiveStateDialog: null | SelectInteractiveStateDialogProps
-  fileStatus?: { message: string, type: string };
-  dirty: boolean;
+  fileStatus?: { message: string, type: string }
+  dirty: boolean
 }
 
 class AppView extends React.Component<IAppViewProps, IAppViewState> {

--- a/src/code/views/modal-dialog-view.tsx
+++ b/src/code/views/modal-dialog-view.tsx
@@ -2,9 +2,9 @@ import React from "react"
 import ModalView from "./modal-view"
 
 interface IProps {
-  title?: string;
-  zIndex?: number;
-  close?: () => void;
+  title?: string
+  zIndex?: number
+  close?: () => void
 }
 const ModalDialogView: React.FC<IProps> = ({ title, zIndex = 10, close, children }) => {
   return (

--- a/src/code/views/modal-view.tsx
+++ b/src/code/views/modal-view.tsx
@@ -2,16 +2,16 @@ import $ from 'jquery'
 import React from 'react'
 
 interface IProps {
-  zIndex: number;
-  close?: () => void;
+  zIndex: number
+  close?: () => void
 }
 interface IState {
-  backgroundStyle: React.CSSProperties;
-  contentStyle: React.CSSProperties;
+  backgroundStyle: React.CSSProperties
+  contentStyle: React.CSSProperties
 }
 interface IDimensions {
-  width: string;
-  height: string;
+  width: string
+  height: string
 }
 export default class ModalView extends React.Component<IProps, IState> {
 

--- a/src/code/views/select-interactive-state-dialog-view.tsx
+++ b/src/code/views/select-interactive-state-dialog-view.tsx
@@ -89,7 +89,7 @@ class SelectInteractiveStateVersion extends React.Component<IProps, IState> {
 export interface SelectInteractiveStateDialogProps {
   state1: IInteractiveStateProps<{}>
   state2: IInteractiveStateProps<{}>
-  interactiveStateAvailable: boolean,
+  interactiveStateAvailable: boolean
   onSelect?: SelectInteractiveStateCallback
   close?: () => void
 }

--- a/src/code/views/share-dialog-status-view.tsx
+++ b/src/code/views/share-dialog-status-view.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import translate from '../utils/translate'
 
 interface IProps {
-  isSharing: boolean;
-  previewLink: string;
-  onToggleShare: (e: React.MouseEvent) => void;
-  onUpdateShare: (e: React.MouseEvent) => void;
+  isSharing: boolean
+  previewLink: string
+  onToggleShare: (e: React.MouseEvent) => void
+  onUpdateShare: (e: React.MouseEvent) => void
 }
 export const ShareDialogStatusView: React.FC<IProps> = ({ isSharing, previewLink, onToggleShare, onUpdateShare }) => {
   return (

--- a/src/code/views/share-dialog-tabs-view.tsx
+++ b/src/code/views/share-dialog-tabs-view.tsx
@@ -4,15 +4,15 @@ import socialIcons from 'svg-social-icons/lib/icons.json'
 import translate from '../utils/translate'
 
 interface SVGSocialIcon {
-  icon: string;   // SVG icon path string
-  mask: string;   // SVG mask path string
-  color: string;
+  icon: string   // SVG icon path string
+  mask: string   // SVG mask path string
+  color: string
 }
 type SVGSocialIconMap = Record<string, SVGSocialIcon>
 
 interface ISocialIconProps {
-  icon: string;
-  url: string;
+  icon: string
+  url: string
 }
 const SocialIcon = ({ icon, url }: ISocialIconProps) => {
   const socialIcon = (socialIcons as SVGSocialIconMap)[icon]
@@ -36,7 +36,7 @@ const SocialIcon = ({ icon, url }: ISocialIconProps) => {
 }
 
 interface ICopyAnchorLinkProps {
-  onClick: (e: React.MouseEvent) => void;
+  onClick: (e: React.MouseEvent) => void
 }
 const CopyAnchorLink = ({ onClick }: ICopyAnchorLinkProps) => {
   return document.execCommand || (window as any).clipboardData
@@ -47,8 +47,8 @@ const CopyAnchorLink = ({ onClick }: ICopyAnchorLinkProps) => {
 }
 
 interface IEmbedTabProps {
-  url: string;
-  onCopyClick: (e: React.MouseEvent) => void;
+  url: string
+  onCopyClick: (e: React.MouseEvent) => void
 }
 export const EmbedTabContents: React.FC<IEmbedTabProps> = ({ url, onCopyClick }) => {
   return (
@@ -63,16 +63,16 @@ export const EmbedTabContents: React.FC<IEmbedTabProps> = ({ url, onCopyClick })
 }
 
 export interface ILaraApiTabProps {
-  mode: 'lara' | 'api';
-  linkUrl: string;
-  serverUrlLabel: string;
-  serverUrl: string;
-  fullscreenScaling?: boolean;
-  visibilityToggles?: boolean;
-  onCopyClick: (e: React.MouseEvent) => void;
-  onChangeServerUrl: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onChangeFullscreenScaling?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onChangeVisibilityToggles?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  mode: 'lara' | 'api'
+  linkUrl: string
+  serverUrlLabel: string
+  serverUrl: string
+  fullscreenScaling?: boolean
+  visibilityToggles?: boolean
+  onCopyClick: (e: React.MouseEvent) => void
+  onChangeServerUrl: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChangeFullscreenScaling?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChangeVisibilityToggles?: (e: React.ChangeEvent<HTMLInputElement>) => void
 }
 export const LaraApiTabContents: React.FC<ILaraApiTabProps> = ({
         mode, linkUrl, serverUrlLabel, serverUrl, fullscreenScaling, visibilityToggles,
@@ -108,8 +108,8 @@ export const LaraApiTabContents: React.FC<ILaraApiTabProps> = ({
 }
 
 interface ILinkTabProps {
-  url: string;
-  onCopyClick: (e: React.MouseEvent) => void;
+  url: string
+  onCopyClick: (e: React.MouseEvent) => void
 }
 export const LinkTabContents: React.FC<ILinkTabProps> = ({ url, onCopyClick }) => {
   const encodedUrl = encodeURIComponent(url)
@@ -133,22 +133,22 @@ export const LinkTabContents: React.FC<ILinkTabProps> = ({ url, onCopyClick }) =
 
 export type ShareDialogTab = 'api' | 'embed' | 'lara' | 'link'
 export interface IShareDialogLaraApiTabProps {
-  linkUrl: string;
-  serverUrlLabel: string;
-  serverUrl: string;
-  onChangeServerUrl: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  linkUrl: string
+  serverUrlLabel: string
+  serverUrl: string
+  onChangeServerUrl: (e: React.ChangeEvent<HTMLInputElement>) => void
 }
 interface IShareDialogTabsProps {
-  tabSelected: ShareDialogTab;
-  linkUrl: string;
-  embedUrl: string;
-  interactiveApi?: IShareDialogLaraApiTabProps;
-  fullscreenScaling?: boolean;
-  visibilityToggles?: boolean;
-  onChangeFullscreenScaling?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onChangeVisibilityToggles?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onSelectTab: (tab: ShareDialogTab) => void;
-  onCopyClick: (e: React.MouseEvent) => void;
+  tabSelected: ShareDialogTab
+  linkUrl: string
+  embedUrl: string
+  interactiveApi?: IShareDialogLaraApiTabProps
+  fullscreenScaling?: boolean
+  visibilityToggles?: boolean
+  onChangeFullscreenScaling?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChangeVisibilityToggles?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onSelectTab: (tab: ShareDialogTab) => void
+  onCopyClick: (e: React.MouseEvent) => void
 }
 export const ShareDialogTabsView: React.FC<IShareDialogTabsProps> = ({
               tabSelected, embedUrl, linkUrl, interactiveApi, onSelectTab, onCopyClick, ...others

--- a/src/code/views/share-dialog-view.tsx
+++ b/src/code/views/share-dialog-view.tsx
@@ -15,32 +15,32 @@ const CODAP_PRODUCTION_URL = "https://codap.concord.org/releases/latest/"
 const FULLSCREEN_INTERACTIVE_URL = "https://models-resources.concord.org/question-interactives/full-screen/"
 
 interface IShareDialogPropsSettings {
-  serverUrl?: string;
-  serverUrlLabel?: string;
+  serverUrl?: string
+  serverUrlLabel?: string
 }
 interface IShareDialogProps {
-  currentBaseUrl: string;
-  isShared: boolean;
-  sharedDocumentId?: string;  // to support legacy shares
-  sharedDocumentUrl?: string;
-  settings?: IShareDialogPropsSettings;
-  enableLaraSharing?: boolean;
-  onAlert: (message: string, title?: string) => void;
-  onToggleShare: (callback: (err: string | null, sharedContentId?: string) => void) => void;
-  onUpdateShare: () => void;
-  close: () => void;
+  currentBaseUrl: string
+  isShared: boolean
+  sharedDocumentId?: string  // to support legacy shares
+  sharedDocumentUrl?: string
+  settings?: IShareDialogPropsSettings
+  enableLaraSharing?: boolean
+  onAlert: (message: string, title?: string) => void
+  onToggleShare: (callback: (err: string | null, sharedContentId?: string) => void) => void
+  onUpdateShare: () => void
+  close: () => void
 }
 interface IShareDialogState {
-  link: string | null;
-  embed: string | null;
-  laraServerUrl: string;
-  laraServerUrlLabel: string;
-  interactiveApiServerUrl: string;
-  interactiveApiServerUrlLabel: string;
-  fullscreenScaling: boolean;
-  graphVisToggles: boolean;
-  tabSelected: ShareDialogTab;
-  isLoadingShared: boolean;
+  link: string | null
+  embed: string | null
+  laraServerUrl: string
+  laraServerUrlLabel: string
+  interactiveApiServerUrl: string
+  interactiveApiServerUrlLabel: string
+  fullscreenScaling: boolean
+  graphVisToggles: boolean
+  tabSelected: ShareDialogTab
+  isLoadingShared: boolean
 }
 
 export default class ShareDialogView extends React.Component<IShareDialogProps, IShareDialogState> {


### PR DESCRIPTION
This started with the simple task of updating the ReadMe with information about the new `@concord-consortium/cloud-file-manager` library option.
- While at it I decided to add some information about the options that could be passed to the CFM in the ReadMe as well.
- While doing that it seemed like some additional comments about the meaning of some of the options was warranted, although I bailed out before documenting all of them.
- Finally, while looking at the definitions of the various options I was struck by the number of semicolons in this supposedly semicolon-less project and updated the ESLint configuration to make things more consistent.