### PR TITLE
Version 1.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloud-file-manager",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cloud-file-manager",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/lara-interactive-api": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/concord-consortium/cloud-file-manager"


### PR DESCRIPTION
This is a hotfix off the 1.9.0 release and not master that removes the change user link in the Google Dialog.  That link causes more scopes to be requested than required.