### PR TITLE
feat: improve ability to import as npm library (support CODAP v3)

### DIFF
--- a/src/code/app-options.ts
+++ b/src/code/app-options.ts
@@ -132,6 +132,7 @@ export interface CFMAppOptions {
   // false (default) if CFM sets page title from document name
   appSetsWindowTitle?: boolean
   wrapFileContent?: boolean
+  isClientContent?: (content: unknown) => boolean
   mimeType?: string
   // note different capitalization from CFMBaseProviderOptions
   readableMimeTypes?: string[]

--- a/src/code/client.test.ts
+++ b/src/code/client.test.ts
@@ -14,9 +14,9 @@ mockApi.getInitInteractiveMessage.mockImplementation(() => Promise.resolve({
 describe("CloudFileManagerClientEvent", () => {
 
   test('increments id with each event registered', () => {
-    const clientEvent = new CloudFileManagerClientEvent("any")
+    const clientEvent = new CloudFileManagerClientEvent("connected")
     expect(clientEvent.id).toBe(1)
-    const clientEvent2 = new CloudFileManagerClientEvent("any")
+    const clientEvent2 = new CloudFileManagerClientEvent("ready")
     expect(clientEvent2.id).toBe(2)
   })
 })

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -57,15 +57,19 @@ interface IClientState {
 
 export type ClientEventCallback = (...args: any) => void
 
+export type CFMFileChangedEventType = "renamedFile" | "savedFile" | "sharedFile" | "unsharedFile"
+export type CFMFileEventType = CFMFileChangedEventType | "closedFile" | "newedFile" | "openedFile" | "willOpenFile"
+export type CloudFileManagerEventType = "connected" | "getContent" | "importedData" | "log" | "ready" |
+              "rendered" | "requiresUserInteraction" | "stateChanged" | CFMFileEventType
 
 class CloudFileManagerClientEvent {
   callback: ClientEventCallback
   data: any
   id: number
   state: Partial<IClientState>
-  type: string
+  type: CloudFileManagerEventType
 
-  constructor(type: string, data?: any, callback: ClientEventCallback = null, state?: Partial<IClientState>) {
+  constructor(type: CloudFileManagerEventType, data?: any, callback: ClientEventCallback = null, state?: Partial<IClientState>) {
     this.type = type
     if (data == null) { data = {} }
     this.data = data
@@ -138,6 +142,7 @@ class CloudFileManagerClient {
     this.appOptions = appOptions
     if (this.appOptions.wrapFileContent == null) { this.appOptions.wrapFileContent = true }
     CloudContent.wrapFileContent = this.appOptions.wrapFileContent
+    if (this.appOptions.isClientContent) cloudContentFactory.isClientContent = this.appOptions.isClientContent
 
     type ProviderClass = any
     const allProviders: Record<string, ProviderClass> = {}
@@ -1274,7 +1279,7 @@ class CloudFileManagerClient {
     }
   }
 
-  _fileChanged(type: 'savedFile' | 'sharedFile' | 'unsharedFile' | 'renamedFile', content: any, metadata: CloudMetadata, additionalState?: any, hashParams: string = null) {
+  _fileChanged(type: CFMFileChangedEventType, content: any, metadata: CloudMetadata, additionalState?: any, hashParams: string = null) {
     if (additionalState == null) { additionalState = {} }
 
     this._updateMetaDataOverwritable(metadata)
@@ -1323,7 +1328,7 @@ class CloudFileManagerClient {
     return this._setState(state)
   }
 
-  _event(type: string, data?: any, eventCallback: ClientEventCallback = null) {
+  _event(type: CloudFileManagerEventType, data?: any, eventCallback: ClientEventCallback = null) {
     if (data == null) { data = {} }
     const event = new CloudFileManagerClientEvent(type, data, eventCallback, this.state)
     for (let listener of this._listeners) {

--- a/src/code/ui.ts
+++ b/src/code/ui.ts
@@ -133,6 +133,11 @@ class CloudFileManagerUI {
   client: CloudFileManagerClient
   listenerCallbacks: UIEventListenerCallback[]
   menu: CloudFileManagerUIMenu
+  // set up promise to be resolved when initialization is complete
+  resolveIsInitialized: (isInitialized: boolean) => void
+  isInitialized = new Promise<boolean>((resolve, reject) => {
+    this.resolveIsInitialized = resolve
+  })
 
   constructor(client: CloudFileManagerClient) {
     this.client = client
@@ -157,7 +162,10 @@ class CloudFileManagerUI {
   }
 
   listenerCallback(evt: CloudFileManagerUIEvent) {
-    return Array.from(this.listenerCallbacks).map((callback) => callback(evt))
+    // wait until listeners have been installed before calling them
+    this.isInitialized.then(() => {
+      Array.from(this.listenerCallbacks).map((callback) => callback(evt))
+    })
   }
 
   appendMenuItem(item: CFMMenuItem) {

--- a/src/code/views/app-view.tsx
+++ b/src/code/views/app-view.tsx
@@ -145,9 +145,9 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
         case 'connected':
           return this.setState({menuItems: (this.props.client._ui.menu != null ? this.props.client._ui.menu.items : undefined) || []})
       }
-  })
+    })
 
-    return this.props.client._ui.listen((event: CloudFileManagerUIEvent) => {
+    this.props.client._ui.listen((event: CloudFileManagerUIEvent) => {
       const {menuOptions} = this.state
       switch (event.type) {
         case 'showProviderDialog':
@@ -215,6 +215,8 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
           return this.setState({menuOptions: this.state.menuOptions})
       }
     })
+
+    this.props.client._ui.resolveIsInitialized(true)
   }
 
   _getMenuItemIndex = (key: string) => {

--- a/src/style/app.styl
+++ b/src/style/app.styl
@@ -7,7 +7,7 @@ body
   margin 0px
   background-color #eee
 
-.app
+.app, .view
   absolute(0, 0, 0, 0)
   text-align left
 

--- a/src/style/mixins/default.styl
+++ b/src/style/mixins/default.styl
@@ -29,14 +29,12 @@ flex-content(flex-grow=1, flex-shrink=0, flex-basis=10px)
   -webkit-flex-grow flex-grow
   -webkit-flex-shrink flex-shrink
 
-absolute(top = 'auto', left = 'auto', right = 'auto', bottom = 'auto', height = 'auto', width = 'auto')
+absolute(top, left, right, bottom)
   position absolute
   top top
   left left
   right right
   bottom bottom
-  height height
-  width width
 
 no-select()
    -webkit-touch-callout none


### PR DESCRIPTION
The goal here, as with other recent PRs, is to enable/improve support for clients such as CODAP v3 to load the CFM as an npm library while not changing the behavior of the CFM for existing clients such as CODAP v2 and Sage Modeler.

- New configuration option `isClientContent`
  - Previously, CFM assumed that client content had a top-level `metadata` property. This assumption is preserved for backward-compatibility, but now clients can specify a custom function for identifying client content. CODAP v3 uses this to pass a custom function that can recognize CODAP v2 or v3 documents.
- Fix `ProviderInterface.getClientContent` so that it respects the `wrapFileContent` setting.
  - The `getClientContent` function is one side of a coin with the `getContent` function on the other side.
  - The `getContent` function already made use of the `wrapFileContent` setting to determine whether to return top-level or wrapped content.
  - The `getClientContent` function in contrast made an assumption about the form of the content rather than respecting the `wrapFileContent` setting.
  - The CODAP v3 file format has a `content` property which violates the content assumption made by the previous code, but use of the `wrapFileContent` setting should lead to the correct result in all circumstances.
-  Use enumerated `CloudFileManagerEventType` rather than `string` for CFM event types for better type-safety in event manipulation code.
- Fix latent race condition in which clients could call into CFM before necessary event handlers were installed.
  - If the client calls the `clientConnect` function promptly the CFM can send the `connected` event to the client before the CFM has been fully initialized. In particular, event handlers for functions like `setMenuBarInfo` are installed in `AppView`'s `componentDidMount` method. If the client calls `setMenuBarInfo` upon receipt of the `connected` event, this can occur before the necessary handlers have been installed.
  - Therefore, we add a promise which resolves when initialization is complete and wait for that promise to be resolved before handling any client callbacks.
- Fix styling of top-level `view` class.
  - When iframed, CFM's top-level `div` is given a class of `app`.
  - When not iframed, CFM's top-level `div` is given a class of `view`.
  - TODO for the future: use less generic class names to avoid conflicts with clients.
  - The CFM .css explicitly styled the `app` class, but relied on clients to style the `view` class.
  - The primary client of non-iframed CFM is CODAP, which styled the `view` class identically to the `app` class, namely absolutely positioned and taking up 100% of its parent.
  - Therefore, we move that styling into the CFM's .css for consistency.
- Fix implementation of stylus `absolute` function
  - In debugging the previous .css change, I noticed invalid `width` and `height` properties being generated for the `app` and `view` classes.
  - This turned out to be because the `absolute` function defaulted all of its arguments to `'auto'`. Unfortunately, while `auto` is a valid value for `height` or `width`, `'auto'` is not.
  - It turns out that all existing calls to the `absolute` function specified exactly four arguments -- `top`, `left`, `bottom`, `right` -- and so the resulting `height` or `width` values were always invalid and hence always ignored by the browser.
  - Therefore, the `absolute` function has been changed to require exactly four arguments and not perform any argument-defaulting.