### PR TITLE
fix: style fixes/tweaks for npm library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.0.0-pre.1",
+  "version": "2.0.0-pre.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.0.0-pre.1",
+      "version": "2.0.0-pre.2",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/lara-interactive-api": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.0.0-pre.1",
+  "version": "2.0.0-pre.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/concord-consortium/cloud-file-manager"

--- a/src/style/components/tabbed-panel.styl
+++ b/src/style/components/tabbed-panel.styl
@@ -96,8 +96,8 @@
             text-decoration underline
       .buttons
         position absolute
-        bottom 10
-        right 10
+        bottom 10px
+        right 10px
         button
           modal-button()
           margin-left 10px

--- a/src/style/mixins/components.styl
+++ b/src/style/mixins/components.styl
@@ -1,4 +1,5 @@
 modal-button($thickness=15px)
+  line-height normal
   padding $thickness
   label-font(weight:bold, size:$thickness)
   color #fff
@@ -10,4 +11,3 @@ modal-button($thickness=15px)
 
 .clickable
   cursor: pointer
-  


### PR DESCRIPTION
- add missing `px` to inadvertently dimensionless values
- specify `line-height normal` for `modal-button` so it doesn't default to something else in CODAP v3
- bump version to 2.0.0-pre.2
