### PR TITLE
fix: export CFM version number rather than `__PACKAGE_VERSION__`

### DIFF
--- a/bin/build-library.sh
+++ b/bin/build-library.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Developed with the help of ChatGPT
+
+# Set the locale for the script to the C locale
+export LC_ALL=C
+
+# Path to your package.json file
+PACKAGE_JSON_PATH="./package.json"
+
+# Path to TypeScript command
+TSC="./node_modules/.bin/tsc"
+
+# Directory containing the files for replacement
+DIST_DIR="./dist"
+
+# Use grep with a regular expression to extract the version number
+VERSION=$(grep '"version":' "$PACKAGE_JSON_PATH" | sed -E 's/.*"version": "([^"]+)",?/\1/')
+
+if [ -z "$VERSION" ]; then
+    echo "Version number not found."
+    exit 1
+fi
+
+echo -e "\nBuilding the CommonJS library folder..."
+$TSC -p tsconfig-cjs.json
+
+echo -e "\nBuilding the ES6 library folder..."
+$TSC -p tsconfig-esm.json
+
+# Replace all occurrences of __PACKAGE_VERSION__ in exported files
+echo -e "\nSetting the version number to '$VERSION'..."
+find "$DIST_DIR/cjs" -type f -exec sed -i '' -e "s/__PACKAGE_VERSION__/$VERSION/g" {} +
+find "$DIST_DIR/esm" -type f -exec sed -i '' -e "s/__PACKAGE_VERSION__/$VERSION/g" {} +
+
+echo -e "\nBuild complete\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.0.0-pre.2",
+  "version": "2.0.0-pre.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.0.0-pre.2",
+      "version": "2.0.0-pre.3",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/lara-interactive-api": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.0.0-pre.2",
+  "version": "2.0.0-pre.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/concord-consortium/cloud-file-manager"
@@ -97,7 +97,7 @@
     "clean": "rimraf dist",
     "build": "npm run clean && NODE_ENV=development webpack",
     "build:all": "npm run build:production && npm run build:library",
-    "build:library": "tsc -p tsconfig-cjs.json && tsc -p tsconfig-esm.json",
+    "build:library": "./bin/build-library.sh",
     "build:production": "npm run clean && NODE_ENV=production webpack",
     "build:codap": "npm run clean && cross-env-shell NODE_ENV=production dest=../codap/apps/dg/resources/cloud-file-manager codap=1 noGlobals=1 noMap=1 'webpack && mv $dest/js/app.js $dest/js/app.js.ignore'",
     "build:codap:development": "npm run clean && cross-env-shell NODE_ENV=development dest=../codap/apps/dg/resources/cloud-file-manager codap=1 noGlobals=1 noMap=1 'webpack && mv $dest/js/app.js $dest/js/app.js.ignore'",


### PR DESCRIPTION
The CFM code contains the string `__PACKAGE_VERSION__` in several places. The expectation is that this string will be replaced by the actual CFM version number from `package.json` at build time. For the webpack build, this is handled by the `ReplaceInFileWebpackPlugin`. For the library export we don't have a bundler that can handle the string replacement. Therefore, this PR introduces the `build-library.sh` bash script which builds the exported library folders with calls to `tsc`, as before, then also uses `grep` and `sed` to perform the string replacement of the version number. The script was developed with the help of ChatGPT.