### PR TITLE
fix: blank share url in share dialog [PT-188104620]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.0.0-pre.3",
+  "version": "2.0.0-pre.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.0.0-pre.3",
+      "version": "2.0.0-pre.4",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/lara-interactive-api": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.0.0-pre.3",
+  "version": "2.0.0-pre.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/concord-consortium/cloud-file-manager"

--- a/src/code/views/share-dialog-view.tsx
+++ b/src/code/views/share-dialog-view.tsx
@@ -240,23 +240,25 @@ export default class ShareDialogView extends React.Component<IShareDialogProps, 
 
   render() {
     const { isShared } = this.props
-    const { isLoadingShared, link } = this.state
-    const sharing = isShared || (link != null)
+    const { isLoadingShared } = this.state
+    const shareUrl = this.getShareLink()
+    const embedUrl = this.getEmbed()
+    const sharing = isShared || (shareUrl != null)
     return (
       <ModalDialogView title={translate('~DIALOG.SHARED')} close={this.props.close}>
         <div className='share-dialog' data-testid='share-dialog'>
           <div className='share-top-dialog'>
             {isLoadingShared
               ? <ShareLoadingView />
-              : <ShareDialogStatusView isSharing={sharing} previewLink={this.state.link}
+              : <ShareDialogStatusView isSharing={sharing} previewLink={shareUrl}
                   onToggleShare={this.toggleShare} onUpdateShare={this.updateShare}/>}
           </div>
 
           {sharing &&
             <ShareDialogTabsView
               tabSelected={this.state.tabSelected}
-              linkUrl={this.state.link}
-              embedUrl={this.state.embed}
+              linkUrl={shareUrl}
+              embedUrl={embedUrl}
               interactiveApi={this.props.enableLaraSharing
                 ? {
                     linkUrl: this.getInteractiveApiLink(),


### PR DESCRIPTION
The `ShareDialogView` is responsible for displaying the various sharing urls, embedding urls, etc. that result from sharing a document. It constructs these urls from constituent parts passed into it as props, e.g. `sharedDocumentId` and `sharedDocumentUrl`. Utility methods in the form of `getShareUrl()`, `getShareLink()`, and `getEmbed()` construct these urls from the provided props. These urls are _also_ stored in state through an asynchronous mechanism that is triggered by the user pressing the `Enable Sharing` button. These state variables are set to the return values of the `getShareLink()` and `getEmbed()` utility methods, which construct them from props, as previously stated. The bug occurs because in v3, the setState callback occurs before the props have been updated, so the state variables are set to empty, and then later the dialog renders the url fields from state, _even though the props have been updated by that time_. So the explanation for the bug is that there is essentially a race condition and that in v3, perhaps due to the update from React 16 to 18, the ordering of events has changed. The justification for the fix is that since the state is set from the props, the props are always at least as current as the state, and so it is safer/preferable to use the props instead of the state when rendering, and so calling `getShareLink()` and `getShareUrl()` when rendering fixes the bug.