### PR TITLE
add share button to no-frame example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "cypress": "^7.7.0",
         "cypress-commands": "^1.1.0",
         "cypress-xpath": "^1.6.2",
+        "dotenv-webpack": "^8.1.0",
         "eslint": "^8.56.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-jest": "^27.6.0",
@@ -4953,6 +4954,42 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-webpack": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.1.0.tgz",
+      "integrity": "sha512-owK1JcsPkIobeqjVrk6h7jPED/W6ZpdFsMPR+5ursB7/SdgDyO+VzAU+szK8C8u3qUhtENyYnj8eyXMR5kkGag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dotenv-defaults": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": "^4 || ^5"
       }
     },
     "node_modules/duplexer": {
@@ -17740,6 +17777,30 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^7.0.0"
+      }
+    },
+    "dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true
+    },
+    "dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dev": true,
+      "requires": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "dotenv-webpack": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.1.0.tgz",
+      "integrity": "sha512-owK1JcsPkIobeqjVrk6h7jPED/W6ZpdFsMPR+5ursB7/SdgDyO+VzAU+szK8C8u3qUhtENyYnj8eyXMR5kkGag==",
+      "dev": true,
+      "requires": {
+        "dotenv-defaults": "^2.0.2"
       }
     },
     "duplexer": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "cypress": "^7.7.0",
     "cypress-commands": "^1.1.0",
     "cypress-xpath": "^1.6.2",
+    "dotenv-webpack": "^8.1.0",
     "eslint": "^8.56.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-jest": "^27.6.0",

--- a/src/assets/examples/no-frame.html
+++ b/src/assets/examples/no-frame.html
@@ -105,6 +105,8 @@
 
     </div>
     <script type="text/javascript">
+      // Use staging so we don't fill up the production shared data examples
+      window.TOKEN_SERVICE_ENV = "staging";
       var clientOptions = {
         mimeType: "text/plain",
         appName: "CFM_Demo",

--- a/src/assets/examples/no-frame.html
+++ b/src/assets/examples/no-frame.html
@@ -18,6 +18,11 @@
     <script type="text/javascript">
       var cfmClient, cfmContent;
 
+      function getQueryVariable(variable) {
+        const urlParams = new URLSearchParams(window.location.search);
+        return urlParams.get(variable)
+      }
+
       // Disable "Expected an assignment or function call and instead saw an expression" warning
       /*jshint -W030 */
       function newFile() {
@@ -37,6 +42,21 @@
         cfmClient && cfmClient.saveFileAsDialog(getContent());
       }
 
+      function share() {
+        document.getElementById("share-info").innerHTML = "Sharing..."
+        cfmClient && cfmClient.share((data) => {
+          const sharedMetadata = cfmClient._sharedMetadata()
+          console.log("share data", sharedMetadata)
+          const { location } = window 
+          const urlParams = new URLSearchParams(location.search);
+          urlParams.set("url", sharedMetadata.sharedDocumentUrl)
+
+          document.getElementById("share-info").innerHTML = 
+            `<a href="${location.origin}${location.pathname}?${urlParams.toString()}">Link to Example loading the shared data</a>`
+        });
+
+      }
+
       function getContent() {
         cfmContent = document.getElementById("text").value;
         return cfmContent;
@@ -50,6 +70,10 @@
       function connected(client) {
         cfmClient = client;
         cfmContent = document.getElementById("text").value;
+        var urlToLoad = getQueryVariable("url");
+        if (urlToLoad) {
+          client.openUrlFile(urlToLoad);
+        }
       }
 
       function changed() {
@@ -64,7 +88,8 @@
   <body>
     <h2>Demo App</h2>
     <p>
-      This simple demo app uses the textarea below to edit text files.  You can either use the menu bar or the buttons below to open, save and create new files.
+      This simple demo app uses the textarea below to edit text files.  You can use the buttons below to open, save, and create new files, 
+      or create a share link to a file.
     </p>
     <div>
       <textarea cols="50" rows="10" id="text"></textarea>
@@ -74,6 +99,10 @@
       <button onclick="openFile()">Open</button>
       <button onclick="saveFile()">Save</button>
       <button onclick="saveFileAs()">Save As</button>
+      <button onclick="share()">Share</button>
+    </div>
+    <div id="share-info">
+
     </div>
     <script type="text/javascript">
       var clientOptions = {

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -915,9 +915,12 @@ class CloudFileManagerClient {
         sharedContent.addMetadata(sharingMetadata)
         const currentContent = this._createOrUpdateCurrentContent(stringContent, this.state.metadata)
         sharedContent.set('docName', currentContent.get('docName'))
-        // save the current name at the top level so it is displayed when the shared file is loaded
+        // try to save the current name at the top level so it is displayed when the shared file is loaded
         if (this.state.metadata) {
-          sharedContent.getClientContent().name = this.state.metadata.name
+          const clientContent = sharedContent.getClientContent()
+          if (typeof clientContent === "object") {
+            clientContent.name = this.state.metadata.name
+          }
         }
         if (shared) {
           currentContent.remove('isUnshared')

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -207,22 +207,30 @@ class CloudFileManagerClient {
         if (allProviders[providerName]) {
           Provider = allProviders[providerName]
           // don't add providers that require configuration if no (or invalid) configuration provided
-          if (!Provider.hasValidOptions || Provider.hasValidOptions(providerOptions)) {
-            const provider = new Provider(providerOptions, this)
-            this.providers[providerName] = provider
-            shareProvider = this._getShareProvider()
-            // also add to here in providers list so we can look it up when parsing url hash
-            if (provider.urlDisplayName) {
-              this.providers[provider.urlDisplayName] = provider
-            }
-            availableProviders.push(provider)
+          if (Provider.hasValidOptions && !Provider.hasValidOptions(providerOptions)) {
+            continue
+          }
 
-            // InteractiveApiProvider is a newer form of Lara provider
-            if (!isInteractiveApiRequested && (providerName === "lara")) {
-              const interactiveApiProvider = new InteractiveApiProvider(providerOptions, this)
-              this.providers.interactiveApi = interactiveApiProvider
-              availableProviders.push(interactiveApiProvider)
-            }
+          const provider = new Provider(providerOptions, this)
+          this.providers[providerName] = provider
+
+          // TODO: It isn't clear why the share provider is being created in this loop.
+          // Perhaps it is so the share provider is not be created if the configuration is `providers: []`
+          if (!shareProvider) {
+            shareProvider = this._getShareProvider()
+          }
+
+          // also add to here in providers list so we can look it up when parsing url hash
+          if (provider.urlDisplayName) {
+            this.providers[provider.urlDisplayName] = provider
+          }
+          availableProviders.push(provider)
+
+          // InteractiveApiProvider is a newer form of Lara provider
+          if (!isInteractiveApiRequested && (providerName === "lara")) {
+            const interactiveApiProvider = new InteractiveApiProvider(providerOptions, this)
+            this.providers.interactiveApi = interactiveApiProvider
+            availableProviders.push(interactiveApiProvider)
           }
         } else {
           this.alert(`Unknown provider: ${providerName}`)

--- a/src/code/utils/config.ts
+++ b/src/code/utils/config.ts
@@ -1,6 +1,6 @@
-export type EnvironmentNameType = "dev" | "staging" | "production"
+import { EnvironmentName } from "@concord-consortium/token-service"
 
-export const getTokenServiceEnv = () =>  (process.env.TOKEN_SERVICE_ENV || "production") as EnvironmentNameType
+export const getTokenServiceEnv = () =>  ((window as any).TOKEN_SERVICE_ENV || process.env.TOKEN_SERVICE_ENV || "production") as EnvironmentName
 export const DEFAULT_MAX_AGE_SECONDS = 60
 export const TOKEN_SERVICE_TOOL_NAME = "cfm-shared"
 export const TOKEN_SERVICE_TOOL_TYPE = "s3Folder"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const { NODE_ENV, dest, codap, noGlobals, noMap } = process.env;
 const CopyPlugin = require('copy-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const ReplaceInFileWebpackPlugin = require('replace-in-file-webpack-plugin')
+const Dotenv = require('dotenv-webpack')
 const { assets, replacementStrings } = require('./build-support/build-opts')
 
 const isProduction = NODE_ENV === 'production'
@@ -54,6 +55,7 @@ const baseConfig = (env) => ({
     extensions: ['.tsx', '.ts', '.js', '.jsx', '.json', '.styl']
   },
   plugins: [
+    new Dotenv(),
     new MiniCssExtractPlugin({
       filename: (pathData) =>
         `${pathData.chunk.name.replace(/js\//, 'css/').replace(/\.js$/, '.css')}`


### PR DESCRIPTION
This fixes a bug when sharing plain text content.
It also fixes a bug that was breaking all sharing in these examples because the sharing provider uses at `process.env`.

The `process.env` reference still exists in the library, so any application using the CFM library needs to handle this reference on its own.

TODO:
- [x] change the token service environment to staging for the examples, so they don't polute the production CFM.