### PR TITLE
[CODAP-801] Support other client-provided menus in the CFM toolbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.1.0-pre.4",
+  "version": "2.1.0-pre.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.1.0-pre.4",
+      "version": "2.1.0-pre.5",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/lara-interactive-api": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.1.0-pre.4",
+  "version": "2.1.0-pre.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concord-consortium/cloud-file-manager.git"

--- a/src/code/app-options.ts
+++ b/src/code/app-options.ts
@@ -17,6 +17,9 @@ export type CFMMenu = CFMMenuItem[]
 
 export interface CFMMenuBarOptions {
   info?: string
+  onInfoClick?: () => void
+  subMenuExpandIcon?: string
+  otherMenus?: CFMUIMenuOptions[]
   languageAnchorIcon?: string
   languageMenu?: {
     currentLang: string
@@ -31,13 +34,13 @@ export interface CFMShareDialogSettings {
 }
 
 export interface CFMUIMenuOptions {
+  className?: string
   // null => no menu; undefined => default menu
   menu?: CFMMenu | null
   menuAnchorIcon?: string
   menuAnchorName?: string
   // map from menu item string to menu display name for string-only menu items
   menuNames?: Record<string, string>
-  subMenuExpandIcon?: string
 }
 
 export interface CFMUIOptions extends CFMUIMenuOptions {

--- a/src/code/views/menu-bar-view.ts
+++ b/src/code/views/menu-bar-view.ts
@@ -28,11 +28,6 @@ export default createReactClass({
       window.addEventListener('touchstart', this.checkBlur, true)
     }
 
-    // Focus the file menu button for keyboard accessibility
-    // if (this.fileMenuButtonRef.current) {
-    //   this.fileMenuButtonRef.current.focus()
-    // }
-
     return this.props.client._ui.listen((event: any) => {
       switch (event.type) {
         case 'editInitialFilename':

--- a/src/style/components/menu-bar.styl
+++ b/src/style/components/menu-bar.styl
@@ -152,6 +152,8 @@
     left 50%
     transform translateX(-15%)
     width max-content
+    .app-logo
+      cursor: pointer
 
   .menu-bar-right
     margin-right 10px
@@ -204,7 +206,7 @@
       background none
       position fixed
       min-width 50px
-      right 10px
+      right 0
       z-index 1000
       color #222
       ul


### PR DESCRIPTION
[[CODAP-801](https://concord-consortium.atlassian.net/browse/CODAP-801)] Move Settings and Help buttons from Tool shelf to CFM header

- Support other client-provided menus in the CFM toolbar
- Make the CODAP logo in the CFM toolbar clickable
- update version to `2.1.0-pre.5` (for testing)

Note that the `Dropdown` component used for menus in the CFM has some undesirable behaviors like not closing menus when the escape key is pressed or the user clicks outside the menu, making it possible to show multiple CFM menus at the same time. I made no effort to fix these issues at this time, although we may (or may not) want to for the beta.

[CODAP-801]: https://concord-consortium.atlassian.net/browse/CODAP-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ