### PR TITLE
fix: styling and closing issues with CFM menus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.1.0-pre.6",
+  "version": "2.1.0-pre.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.1.0-pre.6",
+      "version": "2.1.0-pre.7",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/lara-interactive-api": "^1.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.1.0-pre.5",
+  "version": "2.1.0-pre.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.1.0-pre.5",
+      "version": "2.1.0-pre.6",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/lara-interactive-api": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.1.0-pre.5",
+  "version": "2.1.0-pre.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concord-consortium/cloud-file-manager.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.1.0-pre.6",
+  "version": "2.1.0-pre.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concord-consortium/cloud-file-manager.git"

--- a/src/code/views/dropdown-view.ts
+++ b/src/code/views/dropdown-view.ts
@@ -109,14 +109,16 @@ const DropDown = createReactClass({
   checkClose(evt: any) {
     if (!this.state.showingMenu) { return }
     // if the click is inside the open menu, do nothing
-    const openMenuParent = evt.target.closest(cfmOpenMenuClassSelector)
-    if (openMenuParent) return
+    if (evt.target instanceof Element) {
+      const openMenuParent = evt.target.closest(cfmOpenMenuClassSelector)
+      if (openMenuParent) return
+    }
     // otherwise, close the menu
     return this.setState({showingMenu: false, subMenu: false})
   },
 
   handleKeyDown(evt: KeyboardEvent) {
-    if (evt.key === 'Escape') {
+    if (this.state.showingMenu && evt.key === 'Escape') {
       this.setState({ showingMenu: false, subMenu: false })
     }
   },

--- a/src/code/views/dropdown-view.ts
+++ b/src/code/views/dropdown-view.ts
@@ -77,6 +77,7 @@ const DropdownItem = createReactClassFactory({
 })
 
 const cfmMenuClass = 'cfm-menu dg-wants-touch'
+const cfmOpenMenuClassSelector = '.cfm-menu.dg-wants-touch.menu-showing'
 
 const DropDown = createReactClass({
 
@@ -92,26 +93,32 @@ const DropDown = createReactClass({
   componentDidMount() {
     if (window.addEventListener) {
       window.addEventListener('mousedown', this.checkClose, true)
-      return window.addEventListener('touchstart', this.checkClose, true)
+      window.addEventListener('touchstart', this.checkClose, true)
+      window.addEventListener('keydown', this.handleKeyDown, true)
     }
   },
 
   componentWillUnmount() {
     if (window.removeEventListener) {
       window.removeEventListener('mousedown', this.checkClose, true)
-      return window.removeEventListener('touchstart', this.checkClose, true)
+      window.removeEventListener('touchstart', this.checkClose, true)
+      window.removeEventListener('keydown', this.handleKeyDown, true)
     }
   },
 
   checkClose(evt: any) {
     if (!this.state.showingMenu) { return }
-    let elt = evt.target
-    while (elt != null) {
-      if ((typeof elt.className === "string") && (elt.className.indexOf(cfmMenuClass) >= 0)) { return }
-      elt = elt.parentNode
-    }
+    // if the click is inside the open menu, do nothing
+    const openMenuParent = evt.target.closest(cfmOpenMenuClassSelector)
+    if (openMenuParent) return
     // otherwise, close the menu
     return this.setState({showingMenu: false, subMenu: false})
+  },
+
+  handleKeyDown(evt: KeyboardEvent) {
+    if (evt.key === 'Escape') {
+      this.setState({ showingMenu: false, subMenu: false })
+    }
   },
 
   setSubMenu(subMenu: any) {

--- a/src/style/components/dropdown-menu.styl
+++ b/src/style/components/dropdown-menu.styl
@@ -55,6 +55,7 @@
     .menu-list-icon
       height 18px
       width 18px
+      margin-right 6px
     .submenu-list-arrow
       height 26px
       width 26px
@@ -112,6 +113,7 @@
       .menu-list-icon
         height 18px
         width 18px
+        margin-right 6px
 
     li:hover
       background #e9e9e9

--- a/src/style/components/menu-bar.styl
+++ b/src/style/components/menu-bar.styl
@@ -157,8 +157,8 @@
 
   .menu-bar-right
     margin-right 10px
-    .lang-menu-button
-      margin-left 8px
+    .lang-menu-button, .other-menu-button
+      margin-left 4px
       padding 0 5px 0 0
     .menu
       right 8px


### PR DESCRIPTION
[[CODAP-817](https://concord-consortium.atlassian.net/browse/CODAP-817)] CFM menu issues -- styling, closing

Several issues with CFM menus that may be worth fixing for the beta:
- asymmetric padding on Help/Settings menu button labels
- insufficient space between menu item icons and labels
- can open multiple CFM menus simultaneously
- escape key should close menus

Testable at https://codap3.concord.org/branch/cfm-menu-issues/.

[CODAP-817]: https://concord-consortium.atlassian.net/browse/CODAP-817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ