### PR TITLE
Codap-860 Restyle Copy Button

### DIFF
--- a/cypress/support/elements/CfmObject.js
+++ b/cypress/support/elements/CfmObject.js
@@ -168,8 +168,8 @@ class CfmObject{
     getShareLink(){
         return cy.get('.share-dialog .sharing-tab-contents input')
     }
-    getCopyLink(){
-        return cy.get('.share-dialog .sharing-tab-contents .copy-link')
+    getCopyButton(){
+        return cy.get('.share-dialog .sharing-tab-contents .copy-button')
     }
     getEmbedText(){
         return cy.get('.share-dialog .sharing-tab-contents textarea')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.1.0-pre.9",
+  "version": "2.1.0-pre.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.1.0-pre.9",
+      "version": "2.1.0-pre.10",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/lara-interactive-api": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.1.0-pre.9",
+  "version": "2.1.0-pre.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concord-consortium/cloud-file-manager.git"

--- a/src/code/views/share-dialog-status-view.test.tsx
+++ b/src/code/views/share-dialog-status-view.test.tsx
@@ -12,8 +12,8 @@ describe('ModalDialogView', () => {
         onToggleShare={mockToggle} onUpdateShare={mockUpdate} />
     )
     expect(screen.getByTestId('share-status')).toBeInTheDocument()
-    expect(screen.queryByTestId('toggle-anchor')).toBeNull()
-    expect(screen.queryByTestId('preview-anchor')).toBeNull()
+    expect(screen.queryByTestId('toggle-share-button')).toBeNull()
+    expect(screen.queryByTestId('preview-button')).toBeNull()
 
     await userEvent.click(screen.getByTestId('share-button-element'))
 
@@ -29,8 +29,8 @@ describe('ModalDialogView', () => {
         onToggleShare={mockToggle} onUpdateShare={mockUpdate} />
     )
     expect(screen.getByTestId('share-status')).toBeInTheDocument()
-    expect(screen.getByTestId('toggle-anchor')).toBeInTheDocument()
-    expect(screen.getByTestId('preview-anchor')).toBeInTheDocument()
+    expect(screen.getByTestId('toggle-share-button')).toBeInTheDocument()
+    expect(screen.getByTestId('preview-button')).toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('share-button-element'))
 

--- a/src/code/views/share-dialog-status-view.tsx
+++ b/src/code/views/share-dialog-status-view.tsx
@@ -8,6 +8,7 @@ interface IProps {
   onUpdateShare: (e: React.MouseEvent) => void
 }
 export const ShareDialogStatusView: React.FC<IProps> = ({ isSharing, previewLink, onToggleShare, onUpdateShare }) => {
+  const handlePreviewClick = () => window.open(previewLink, "_blank", "noopener,noreferrer")
   return (
     <div>
       <div className='share-status' data-testid='share-status'>
@@ -22,7 +23,7 @@ export const ShareDialogStatusView: React.FC<IProps> = ({ isSharing, previewLink
         </button>
         <div className={isSharing ? 'share-button-help-sharing' : 'share-button-help-not-sharing'}>
           {isSharing
-            ? <button onClick={() => window.open(previewLink, "_blank")} data-testid='preview-button'>
+            ? <button onClick={handlePreviewClick} data-testid='preview-button'>
                 {translate("~SHARE_DIALOG.PREVIEW_SHARING")}
               </button>
             : <span>{translate("~SHARE_DIALOG.ENABLE_SHARING_MESSAGE")}</span>

--- a/src/code/views/share-dialog-status-view.tsx
+++ b/src/code/views/share-dialog-status-view.tsx
@@ -14,24 +14,25 @@ export const ShareDialogStatusView: React.FC<IProps> = ({ isSharing, previewLink
         {translate("~SHARE_DIALOG.SHARE_STATE")}
         <strong>
           {translate(isSharing ? "~SHARE_DIALOG.SHARE_STATE_ENABLED" : "~SHARE_DIALOG.SHARE_STATE_DISABLED")}
-          {isSharing &&
-            <a href='#' onClick={onToggleShare} data-testid='toggle-anchor'>
-              {translate("~SHARE_DIALOG.STOP_SHARING")}
-            </a>
-          }
         </strong>
       </div>
-      <div className='share-button'>
+      <div className='share-buttons'>
         <button onClick={isSharing ? onUpdateShare : onToggleShare} data-testid='share-button-element'>
           {translate(isSharing ? "~SHARE_DIALOG.UPDATE_SHARING" : "~SHARE_DIALOG.ENABLE_SHARING")}
         </button>
         <div className={isSharing ? 'share-button-help-sharing' : 'share-button-help-not-sharing'}>
           {isSharing
-            ? <a href={previewLink} target="_blank" rel="noreferrer" data-testid='preview-anchor'>
+            ? <button onClick={() => window.open(previewLink, "_blank")} data-testid='preview-button'>
                 {translate("~SHARE_DIALOG.PREVIEW_SHARING")}
-              </a>
-            : translate("~SHARE_DIALOG.ENABLE_SHARING_MESSAGE")}
+              </button>
+            : <span>{translate("~SHARE_DIALOG.ENABLE_SHARING_MESSAGE")}</span>
+          }
         </div>
+        {isSharing &&
+          <button onClick={onToggleShare} data-testid="toggle-share-button">
+            {translate("~SHARE_DIALOG.STOP_SHARING")}
+          </button>
+        }
       </div>
     </div>
   )

--- a/src/code/views/share-dialog-tabs-view.test.tsx
+++ b/src/code/views/share-dialog-tabs-view.test.tsx
@@ -26,9 +26,9 @@ describe('ShareDialogTabsView', () => {
     expect(screen.getByTestId('link-tab-contents')).toBeInTheDocument()
     expect(screen.queryByTestId('embed-tab-contents')).toBeNull()
     expect(screen.queryByTestId('lara-api-tab-contents')).toBeNull()
-    expect(screen.getByTestId('copy-anchor-link')).toBeInTheDocument()
+    expect(screen.getByTestId('copy-button')).toBeInTheDocument()
 
-    await userEvent.click(screen.getByTestId('copy-anchor-link'))
+    await userEvent.click(screen.getByTestId('copy-button'))
     await userEvent.click(screen.getByTestId('sharing-tab-embed'))
 
     expect(mockCopy).toHaveBeenCalledTimes(1)
@@ -46,9 +46,9 @@ describe('ShareDialogTabsView', () => {
     expect(screen.queryByTestId('link-tab-contents')).toBeNull()
     expect(screen.getByTestId('embed-tab-contents')).toBeInTheDocument()
     expect(screen.queryByTestId('lara-api-tab-contents')).toBeNull()
-    expect(screen.getByTestId('copy-anchor-link')).toBeInTheDocument()
+    expect(screen.getByTestId('copy-button')).toBeInTheDocument()
 
-    await userEvent.click(screen.getByTestId('copy-anchor-link'))
+    await userEvent.click(screen.getByTestId('copy-button'))
     await userEvent.click(screen.getByTestId('sharing-tab-link'))
 
     expect(mockCopy).toHaveBeenCalledTimes(2)
@@ -66,7 +66,7 @@ describe('ShareDialogTabsView', () => {
     expect(screen.queryByTestId('link-tab-contents')).toBeNull()
     expect(screen.queryByTestId('embed-tab-contents')).toBeNull()
     expect(screen.queryByTestId('lara-api-tab-contents')).toBeNull()
-    expect(screen.queryByTestId('copy-anchor-link')).toBeNull()
+    expect(screen.queryByTestId('copy-button')).toBeNull()
   })
 
   it('renders with interactive api sharing', async () => {

--- a/src/code/views/share-dialog-tabs-view.tsx
+++ b/src/code/views/share-dialog-tabs-view.tsx
@@ -38,11 +38,11 @@ const SocialIcon = ({ icon, url }: ISocialIconProps) => {
 interface ICopyAnchorLinkProps {
   onClick: (e: React.MouseEvent) => void
 }
-const CopyAnchorLink = ({ onClick }: ICopyAnchorLinkProps) => {
+const CopyButton = ({ onClick }: ICopyAnchorLinkProps) => {
   return document.execCommand || (window as any).clipboardData
-          ? <a className='copy-link' href='#' onClick={onClick} data-testid='copy-anchor-link'>
+          ? <button className='copy-button' onClick={onClick} data-testid='copy-button'>
               {translate('~SHARE_DIALOG.COPY')}
-            </a>
+            </button>
           : null
 }
 
@@ -54,9 +54,9 @@ export const EmbedTabContents: React.FC<IEmbedTabProps> = ({ url, onCopyClick })
   return (
     <div data-testid='embed-tab-contents'>
       {translate("~SHARE_DIALOG.EMBED_MESSAGE")}
-      <CopyAnchorLink onClick={onCopyClick} />
-      <div>
+      <div className="share-url-container">
         <textarea value={url || ""} readOnly={true} />
+        <CopyButton onClick={onCopyClick} />
       </div>
     </div>
   )
@@ -81,9 +81,9 @@ export const LaraApiTabContents: React.FC<ILaraApiTabProps> = ({
   return (
     <div className={mode} data-testid='lara-api-tab-contents'>
       {translate(mode === 'lara' ? '~SHARE_DIALOG.LARA_MESSAGE' : '~SHARE_DIALOG.INTERACTIVE_API_MESSAGE')}
-      <CopyAnchorLink onClick={onCopyClick}/>
-      <div>
+      <div className="share-url-container">
         <input value={linkUrl} readOnly={true} />
+        <CopyButton onClick={onCopyClick}/>
       </div>
       <div className='lara-api-settings'>
         <div className='codap-server-url'>
@@ -119,9 +119,9 @@ export const LinkTabContents: React.FC<ILinkTabProps> = ({ url, onCopyClick }) =
   return (
     <div data-testid='link-tab-contents'>
       {translate("~SHARE_DIALOG.LINK_MESSAGE")}
-      <CopyAnchorLink onClick={onCopyClick} />
-      <div>
+      <div className="share-url-container">
         <input value={url || ""} readOnly={true} />
+        <CopyButton onClick={onCopyClick} />
       </div>
       <div className='social-icons'>
         <SocialIcon icon='facebook' url={facebookUrl} />

--- a/src/code/views/share-dialog-view.test.tsx
+++ b/src/code/views/share-dialog-view.test.tsx
@@ -17,8 +17,8 @@ describe('ShareDialogView', () => {
         onAlert={mockAlert} onToggleShare={mockToggleShare} onUpdateShare={mockUpdateShare} close={mockClose} />
     )
     expect(screen.getByTestId('share-dialog')).toBeInTheDocument()
-    expect(screen.queryByTestId('toggle-anchor')).toBeNull()
-    expect(screen.queryByTestId('preview-anchor')).toBeNull()
+    expect(screen.queryByTestId('toggle-share-button')).toBeNull()
+    expect(screen.queryByTestId('preview-button')).toBeNull()
 
     await userEvent.click(screen.getByTestId('share-button-element'))
 

--- a/src/code/views/share-dialog-view.test.tsx
+++ b/src/code/views/share-dialog-view.test.tsx
@@ -50,7 +50,7 @@ describe('ShareDialogView', () => {
     expect(mockToggleShare).not.toHaveBeenCalled()
     expect(mockUpdateShare).toHaveBeenCalled()
 
-    await userEvent.click(screen.getByTestId('copy-anchor-link'))
+    await userEvent.click(screen.getByTestId('copy-button'))
     await userEvent.click(screen.getByTestId('sharing-tab-embed'))
 
     rerender(
@@ -59,7 +59,7 @@ describe('ShareDialogView', () => {
         onAlert={mockAlert} onToggleShare={mockToggleShare} onUpdateShare={mockUpdateShare} close={mockClose} />
     )
 
-    await userEvent.click(screen.getByTestId('copy-anchor-link'))
+    await userEvent.click(screen.getByTestId('copy-button'))
     await userEvent.click(screen.getByTestId('sharing-tab-link'))
 })
 
@@ -117,7 +117,7 @@ describe('ShareDialogView', () => {
     )
 
     // copy interactive api share url
-    await userEvent.click(screen.getByTestId('copy-anchor-link'))
+    await userEvent.click(screen.getByTestId('copy-button'))
 
     // trigger change handlers
     fireEvent.change(screen.getByTestId('server-url-input'), { target: { value: 'https://concord.org/newServerUrl' } })

--- a/src/style/components/share-dialog.styl
+++ b/src/style/components/share-dialog.styl
@@ -55,8 +55,22 @@
     border-top 1px solid #000
     border-bottom 1px solid #000
 
-    .copy-link
+    .share-url-container
+      align-items center
+      display flex
+      flex-direction row
+      justify-content space-between
+
+    .copy-button
+      background-color #72bfca
+      border-radius 5px
+      color white
+      font-weight bold
+      padding 5px 10px
       margin-left 10px
+
+      &:hover
+        background-color darken(#72bfca, 30%)
 
     .social-icons
       margin-top 10px
@@ -96,7 +110,7 @@
           fill: #0f0b0b;
 
     input
-      margin-top 5px
+      margin-top 10px
       margin-bottom 10px
       padding 5px
       width 100%

--- a/src/style/components/share-dialog.styl
+++ b/src/style/components/share-dialog.styl
@@ -17,10 +17,13 @@
       font-size 14px
       margin-left 10px
 
-  .share-button
-    display flex
-    gap 20px
+  .share-buttons
     align-items center
+    display flex
+    flex-direction row
+    gap 20px
+    justify-content space-evenly
+    width 100%
 
     button
       modal-button()
@@ -118,6 +121,9 @@
       width unset !important
       margin-bottom unset
     textarea
+      border 1px solid rgb(118, 118, 118)
+      border-radius 3px
+      border-style inset
       margin-top 5px
       width 100%
       padding 5px


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/CODAP-860

This story improves the styling for the share modal:
- The button for copying a share url is now an actual button that looks like other buttons and is repositioned.
- The preview shared view button is now an actual button and looks like other buttons.
- The stop sharing button looks like other buttons now and has been repositioned.
- The Embed text area now has a border like an input field.

Most of these features can be seen in the attached screenshot.

<img width="1194" height="1084" alt="image" src="https://github.com/user-attachments/assets/869441ec-d7a9-4512-8bb5-35221d246373" />
