### PR TITLE
CODAP-1198: fix Google Picker hang caused by React Aria Modal inert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concord-consortium/cloud-file-manager.git"

--- a/src/code/providers/google-drive-provider.ts
+++ b/src/code/providers/google-drive-provider.ts
@@ -32,6 +32,72 @@ let setGoogleDriveAuthorizationDialogState: undefined | ((newState: any) => void
 
 const { div, button, span, strong, input } = ReactDOMFactories
 
+/**
+ * Prevent React Aria's Modal from making the Google Picker inert.
+ *
+ * This is a known issue with React Aria modals and third-party overlays:
+ * https://github.com/adobe/react-spectrum/issues/8784
+ * A fix is in progress (https://github.com/adobe/react-spectrum/pull/8796)
+ * but not yet released, so we work around it here.
+ *
+ * IMPLEMENTATION NOTE: This workaround relies on internal implementation
+ * details of both React Aria and the Google Picker API that may change:
+ *
+ * - React Aria's ariaHideOutside (in @react-aria/overlays) uses a
+ *   MutationObserver to set `inert` on new elements added to the DOM
+ *   outside the modal scope. It exempts elements with the attribute
+ *   `data-react-aria-top-layer`, which is an internal mechanism for
+ *   React Aria's own overlay stacking (e.g. toasts, nested modals).
+ *
+ * - The Google Picker renders its overlay as direct children of <body>
+ *   with the CSS class "picker" (plus obfuscated classes). The more
+ *   recognizable classes "picker-dialog" and "picker-dialog-bg" are
+ *   added asynchronously after initial insertion, so we must match on
+ *   the "picker" class which is present from the start.
+ *
+ * We use our own MutationObserver (started before picker.setVisible) to
+ * catch picker elements the moment they appear, mark them with
+ * `data-react-aria-top-layer` (so React Aria's focus scope, interact-
+ * outside, and aria-hide logic treat them as part of the modal stack),
+ * and remove `inert` in case React Aria's observer fired first.
+ */
+function watchForGooglePickerOverlay(): MutationObserver {
+
+  const isPickerElement = (el: Element) =>
+    el.classList.contains('picker') && el.parentElement === document.body
+
+  const markElement = (el: Element) => {
+    el.setAttribute('data-react-aria-top-layer', 'true')
+    if (el instanceof HTMLElement) {
+      el.inert = false
+    }
+  }
+
+  // Mark any picker elements that already exist (e.g. reopen scenario).
+  document.body.querySelectorAll(':scope > .picker').forEach(markElement)
+
+  const observer = new MutationObserver(mutations => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node instanceof HTMLElement) {
+          if (isPickerElement(node)) {
+            markElement(node)
+          }
+          // Also check children in case they're wrapped.
+          node.querySelectorAll('.picker').forEach(child => {
+            if (isPickerElement(child)) {
+              markElement(child)
+            }
+          })
+        }
+      }
+    }
+  })
+
+  observer.observe(document.body, { childList: true, subtree: true })
+  return observer
+}
+
 const GoogleFileDialogTabView = createReactClassFactory({
   displayName: 'GoogleFileDialogTabView',
 
@@ -125,7 +191,17 @@ const GoogleFileDialogTabView = createReactClassFactory({
       .addView(starredView)
       .setCallback(this.pickerCallback)
       .build()
+    // Must start watching BEFORE setVisible so our MutationObserver can
+    // mark picker elements before React Aria's observer sets `inert`.
+    this.pickerOverlayObserver?.disconnect()
+    this.pickerOverlayObserver = watchForGooglePickerOverlay()
+
     this.picker.setVisible(true)
+  },
+
+  cleanupPickerOverlayObserver() {
+    this.pickerOverlayObserver?.disconnect()
+    this.pickerOverlayObserver = null
   },
 
   pickerCallback(data: any) {
@@ -199,6 +275,8 @@ const GoogleFileDialogTabView = createReactClassFactory({
       // DON'T call cancel so we keep the outer dialog open
       // this.props.onCancel();
     }
+
+    this.cleanupPickerOverlayObserver()
   },
 
   componentDidMount() {
@@ -216,6 +294,7 @@ const GoogleFileDialogTabView = createReactClassFactory({
   componentWillUnmount() {
     this.picker?.setVisible(false)
     this.picker?.dispose()
+    this.cleanupPickerOverlayObserver()
     this.observer.unobserve(this.ref)
   },
 


### PR DESCRIPTION
## Summary

- React Aria Modal sets `inert` on all elements outside the modal scope, which makes the Google Picker overlay completely unresponsive when opened from the file dialog
- This is a [known React Aria issue](https://github.com/adobe/react-spectrum/issues/8784) with an [in-progress fix](https://github.com/adobe/react-spectrum/pull/8796) not yet released
- Work around it with a MutationObserver that catches Google Picker elements as they are added to the DOM and marks them with `data-react-aria-top-layer` so React Aria treats them as part of the modal stack
- Bumps version to 2.2.6

## Test plan

- [ ] Open the file dialog via keyboard, navigate to Google Drive tab, verify the picker appears and is interactive (clicks work, files can be selected)
- [ ] Open the file dialog via mouse, verify Google Drive picker still works as before
- [ ] After dismissing the picker (cancel), reopen it and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)