### PR TITLE
feat: add LARA log event forwarding from client to interactive API

### DIFF
--- a/src/code/providers/interactive-api-provider.test.ts
+++ b/src/code/providers/interactive-api-provider.test.ts
@@ -34,6 +34,7 @@ describe('InteractiveApiProvider', () => {
     mockApi.setInteractiveState.mockReset()
     mockApi.readAttachment.mockReset()
     mockApi.writeAttachment.mockReset()
+    mockApi.log.mockReset()
   })
 
   afterEach(() => {
@@ -155,6 +156,36 @@ describe('InteractiveApiProvider', () => {
     expect(mockApi.getInitInteractiveMessage).toHaveBeenCalledTimes(1)
     expect(mockApi.getInteractiveState).toHaveBeenCalledTimes(1)
     expect(mockApi.setInteractiveState).toHaveBeenCalledTimes(2)
+  })
+
+  it('should forward client log events to the interactive API log function', async () => {
+    const mockInitInteractiveMessage: Partial<IRuntimeInitInteractive> = {
+      version: 1,
+      mode: "runtime",
+      classInfoUrl: 'https://concord.org/classInfo',
+      interactive: {
+        id: "mw_interactive_100",
+        name: ""
+      }
+    }
+    mockApi.getInitInteractiveMessage
+      .mockImplementation(() => Promise.resolve(mockInitInteractiveMessage))
+    mockFetch.mockImplementation(() => ({ ok: true, json: () => Promise.resolve("foo") }))
+
+    const client = new CloudFileManagerClient()
+    client.setAppOptions({ providers: [] })
+    const provider = new InteractiveApiProvider({}, client)
+    await provider.isReady()
+
+    expect(mockApi.log).not.toHaveBeenCalled()
+
+    client.log('testEvent', { key: 'value' })
+    expect(mockApi.log).toHaveBeenCalledTimes(1)
+    expect(mockApi.log).toHaveBeenCalledWith('testEvent', { key: 'value' })
+
+    client.log('anotherEvent', 'simpleData')
+    expect(mockApi.log).toHaveBeenCalledTimes(2)
+    expect(mockApi.log).toHaveBeenCalledWith('anotherEvent', 'simpleData')
   })
 
   it('should use runRemoteEndpoint in initInteractive message if available', async () => {

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -9,7 +9,8 @@ import {
 }  from './provider-interface'
 import {
   getInitInteractiveMessage, getInteractiveState as _getInteractiveState, IInitInteractive, IInteractiveStateProps,
-  readAttachment, setInteractiveState as _setInteractiveState, writeAttachment, flushStateUpdates
+  readAttachment, setInteractiveState as _setInteractiveState, writeAttachment, flushStateUpdates,
+  log
 } from '@concord-consortium/lara-interactive-api'
 import { SelectInteractiveStateDialogProps } from '../views/select-interactive-state-dialog-view'
 import { isEmptyObject } from '../utils/is-empty-object'
@@ -313,6 +314,14 @@ class InteractiveApiProvider extends ProviderInterface {
         // the second wait caused the tests to fail and this is needed when loading the provider
         // file to get the host domain
         this.initInteractiveMessage = initInteractiveMessage
+
+        console.log("interactive-api-provider: adding client.listen for log events")
+        this.client.listen((event) => {
+          if (event.type === "log") {
+            console.log("interactive-api-provider: received log event from client", event.data)
+            log(event.data.logEvent, event.data.logEventData)
+          }
+        })
 
         Promise.all([
           this.handleRunRemoteEndpoint(initInteractiveMessage),

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -9,8 +9,7 @@ import {
 }  from './provider-interface'
 import {
   getInitInteractiveMessage, getInteractiveState as _getInteractiveState, IInitInteractive, IInteractiveStateProps,
-  readAttachment, setInteractiveState as _setInteractiveState, writeAttachment, flushStateUpdates,
-  log
+  readAttachment, setInteractiveState as _setInteractiveState, writeAttachment, flushStateUpdates, log
 } from '@concord-consortium/lara-interactive-api'
 import { SelectInteractiveStateDialogProps } from '../views/select-interactive-state-dialog-view'
 import { isEmptyObject } from '../utils/is-empty-object'
@@ -315,10 +314,8 @@ class InteractiveApiProvider extends ProviderInterface {
         // file to get the host domain
         this.initInteractiveMessage = initInteractiveMessage
 
-        console.log("interactive-api-provider: adding client.listen for log events")
         this.client.listen((event) => {
           if (event.type === "log") {
-            console.log("interactive-api-provider: received log event from client", event.data)
             log(event.data.logEvent, event.data.logEventData)
           }
         })


### PR DESCRIPTION
Listen for "log" events from the client and forward them to LARA's log() API, enabling interactives to pass log events through CFM.