### PR TITLE
CODAP-141: Fix spurious unsaved-changes dialog on language change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.2.9",
+      "version": "2.2.10",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concord-consortium/cloud-file-manager.git"

--- a/src/code/app-options.ts
+++ b/src/code/app-options.ts
@@ -175,4 +175,7 @@ export interface CFMAppOptions {
   renderRoot?: (content: React.ReactNode, container: HTMLElement) => void
   // when usingIframe, specifies the `allow` property of the iframe (permissions policy)
   iframeAllow?: string
+  // if false, language changes do not trigger a save first
+  // default (undefined or true) preserves legacy behavior, appropriate for apps that reload on language change
+  saveOnLanguageChange?: boolean
 }

--- a/src/code/client.test.ts
+++ b/src/code/client.test.ts
@@ -160,6 +160,67 @@ describe("CloudFileManagerClient", () => {
 
   })
 
+  describe("changeLanguage", () => {
+    let client: CloudFileManagerClient
+
+    beforeEach(() => {
+      client = new CloudFileManagerClient()
+      client.setAppOptions({ providers: ["testProvider"] })
+      client._setState({metadata: {
+        name: "foo.txt",
+        provider: client.providers.testProvider,
+        overwritable: true
+      } as any})
+      client.listen((event) => {
+        if (event.type === "getContent") {
+          event.callback?.("file-content")
+        }
+      })
+    })
+
+    test("skips save when saveOnLanguageChange is false", (done) => {
+      client.appOptions.saveOnLanguageChange = false
+      const saveSpy = jest.spyOn(client, "save")
+      const tempSaveSpy = jest.spyOn(client, "saveTempFile")
+      const confirmSpy = jest.spyOn(client, "confirm")
+
+      client.changeLanguage("fr", (lang) => {
+        expect(lang).toBe("fr")
+        expect(saveSpy).not.toHaveBeenCalled()
+        expect(tempSaveSpy).not.toHaveBeenCalled()
+        expect(confirmSpy).not.toHaveBeenCalled()
+        done()
+      })
+    })
+
+    test("saves and proceeds without confirm/alert dialogs on success (default)", (done) => {
+      const confirmSpy = jest.spyOn(client, "confirm")
+      const alertSpy = jest.spyOn(client, "alert")
+
+      client.changeLanguage("de", (lang) => {
+        expect(lang).toBe("de")
+        expect(confirmSpy).not.toHaveBeenCalled()
+        expect(alertSpy).not.toHaveBeenCalled()
+        done()
+      })
+    })
+
+    test("saves and proceeds without confirm/alert dialogs when saveOnLanguageChange is true", (done) => {
+      client.appOptions.saveOnLanguageChange = true
+      const saveSpy = jest.spyOn(client, "save")
+      const confirmSpy = jest.spyOn(client, "confirm")
+      const alertSpy = jest.spyOn(client, "alert")
+
+      client.changeLanguage("ja", (lang) => {
+        expect(lang).toBe("ja")
+        expect(saveSpy).toHaveBeenCalled()
+        expect(confirmSpy).not.toHaveBeenCalled()
+        expect(alertSpy).not.toHaveBeenCalled()
+        done()
+      })
+    })
+  })
+
   describe("getCurrentUrl", () => {
     let location: Location
     let client: CloudFileManagerClient

--- a/src/code/client.test.ts
+++ b/src/code/client.test.ts
@@ -1,5 +1,6 @@
 import {CloudFileManagerClient, CloudFileManagerClientEvent} from "./client"
 import { CloudContent } from "./providers/provider-interface"
+import { getCurrentLanguage } from "./utils/translate"
 
 jest.mock('@concord-consortium/lara-interactive-api')
 const mockApi = require('@concord-consortium/lara-interactive-api')
@@ -216,6 +217,23 @@ describe("CloudFileManagerClient", () => {
         expect(saveSpy).toHaveBeenCalled()
         expect(confirmSpy).not.toHaveBeenCalled()
         expect(alertSpy).not.toHaveBeenCalled()
+        done()
+      })
+    })
+
+    test("does not change language when save fails", (done) => {
+      // force the test provider's save to report failure
+      client.providers.testProvider.save = (_c: any, _m: any, cb: any) => cb?.("save failed", 500)
+      jest.spyOn(client, "alert").mockImplementation()
+      const langBefore = getCurrentLanguage()
+      const callback = jest.fn()
+
+      client.changeLanguage("xx-fail", callback)
+
+      setImmediate(() => {
+        expect(callback).not.toHaveBeenCalled()
+        expect(getCurrentLanguage()).toBe(langBefore)
+        expect(getCurrentLanguage()).not.toBe("xx-fail")
         done()
       })
     })

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1197,7 +1197,8 @@ class CloudFileManagerClient {
       return finishLanguageChange()
     }
 
-    if (this.state.metadata?.provider?.can(ECapabilities.save)) {
+    const metadata = this.state.metadata
+    if (metadata?.provider?.can(ECapabilities.save, metadata)) {
       // OpenSaveCallback fires only on success; saveFileNoDialog handles save errors
       // itself (alert + retry) and never invokes the callback on failure. The language
       // change is therefore tied to save success — a save failure leaves the language

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1189,20 +1189,25 @@ class CloudFileManagerClient {
 
   changeLanguage(newLangCode: string, callback: (newLangCode?: string) => void) {
     setCurrentLanguage(newLangCode)
-    if (callback) {
-      const postSave = (err: string | null) => {
+    if (!callback) return
+
+    if (this.appOptions.saveOnLanguageChange === false) {
+      return callback(newLangCode)
+    }
+
+    if (this.state.metadata?.provider?.can(ECapabilities.save)) {
+      // OpenSaveCallback fires only on success; saveFileNoDialog handles save errors
+      // itself (alert + retry) and never invokes the callback on failure, so a save
+      // error abandons the language change rather than prompting the user.
+      return this.save(() => callback(newLangCode))
+    } else {
+      return this.saveTempFile((err: string | null) => {
         if (err) {
           this.alert(err)
           return this.confirm(tr('~CONFIRM.CHANGE_LANGUAGE'), () => callback(newLangCode))
-        } else {
-          return callback(newLangCode)
         }
-      }
-      if (this.state.metadata?.provider?.can(ECapabilities.save)) {
-        return this.save((err: string | null) => postSave(err))
-      } else {
-        return this.saveTempFile(postSave)
-      }
+        return callback(newLangCode)
+      })
     }
   }
 

--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -1187,26 +1187,29 @@ class CloudFileManagerClient {
     return (this._autoSaveInterval != null)
   }
 
-  changeLanguage(newLangCode: string, callback: (newLangCode?: string) => void) {
-    setCurrentLanguage(newLangCode)
-    if (!callback) return
+  changeLanguage(newLangCode: string, callback: ((newLangCode?: string) => void) | null = null) {
+    const finishLanguageChange = () => {
+      setCurrentLanguage(newLangCode)
+      callback?.(newLangCode)
+    }
 
     if (this.appOptions.saveOnLanguageChange === false) {
-      return callback(newLangCode)
+      return finishLanguageChange()
     }
 
     if (this.state.metadata?.provider?.can(ECapabilities.save)) {
       // OpenSaveCallback fires only on success; saveFileNoDialog handles save errors
-      // itself (alert + retry) and never invokes the callback on failure, so a save
-      // error abandons the language change rather than prompting the user.
-      return this.save(() => callback(newLangCode))
+      // itself (alert + retry) and never invokes the callback on failure. The language
+      // change is therefore tied to save success — a save failure leaves the language
+      // unchanged, matching the user's likely intent (they'll retry the save).
+      return this.save(finishLanguageChange)
     } else {
       return this.saveTempFile((err: string | null) => {
         if (err) {
           this.alert(err)
-          return this.confirm(tr('~CONFIRM.CHANGE_LANGUAGE'), () => callback(newLangCode))
+          return this.confirm(tr('~CONFIRM.CHANGE_LANGUAGE'), finishLanguageChange)
         }
-        return callback(newLangCode)
+        return finishLanguageChange()
       })
     }
   }


### PR DESCRIPTION
Note: This bug was re-found by @mtirenin during a CC CODAP testing session, but apparently had been logged previously as [CODAP-141](https://concord-consortium.atlassian.net/browse/CODAP-141).

## Summary
- Fix `changeLanguage()` callback bug that produced a spurious "unsaved changes" confirm dialog (and an `[object Object]` alert behind it) on every successful save after opening a Google Drive file.
- Add `saveOnLanguageChange` appOption so consumers that don't reload on language change (e.g. CODAP v3) can skip the save attempt entirely. Default behavior is preserved for apps that do reload.
- Bump version to 2.2.10.

## Background
`changeLanguage()` was treating `save()`'s `OpenSaveCallback` — which is `(content, metadata, savedContent) => void` — as if it were an error-style `(err) => void` callback. On a successful Drive save, `saveFileNoDialog` invokes the callback with `currentContent` as the first argument; that truthy `CloudContent` object was being interpreted as an error string, triggering the alert + confirm dialog. On a real save failure `saveFileNoDialog` shows its own alert and never invokes the callback at all, so the "ask user on failure" branch was actually unreachable — only the success path hit it.

The fix treats the `OpenSaveCallback` firing as success and lets `saveFileNoDialog` handle save errors as it always has. The `saveTempFile` branch (no save-capable provider) still uses the legacy alert + confirm path because `saveTempFile`'s callback genuinely is error-style.

~~No Jira story has been filed for this yet (logged internally only).~~

Fixes [CODAP-141](https://concord-consortium.atlassian.net/browse/CODAP-141).

## Test plan
- [x] New unit tests in `client.test.ts` cover three cases: `saveOnLanguageChange === false` skips save, default path saves without showing dialogs, explicit `true` matches default behavior.
- [x] All 212 existing tests pass; `npm run lint` clean.
- [x] Manually verified in CODAP v3 via yalc 2.2.10: opening a Drive file then changing languages now triggers no dialog.
- [ ] CI green.
- [ ] Reviewer to verify nothing else relies on the previous (broken) `changeLanguage` callback semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CODAP-141]: https://concord-consortium.atlassian.net/browse/CODAP-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CODAP-141]: https://concord-consortium.atlassian.net/browse/CODAP-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ