### PR TITLE
CFM-16: fix Google sign-in label inadvertently reverted

### DIFF
--- a/cypress/support/elements/CfmObject.js
+++ b/cypress/support/elements/CfmObject.js
@@ -201,7 +201,7 @@ class CfmObject{
         //&redirect_uri=storagerelay%3A%2F%2Fhttp%2Flocalhost%3A8080%3Fid%3Dauth382299&client_id=107140815081-p1so3nbhgvbeio1imeigd8sf1ve7l6tj.apps.googleusercontent.com
         //&ss_domain=http%3A%2F%2Flocalhost%3A8080&gsiwebsdk=shim&o2v=1&as=YqVf37GwUvUNK1LOLRAmYA&flowName=GeneralOAuthFlow
         //https://accounts.google.com/signin/oauth/identifier?response_type=permission%20id_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.install%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.file%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&openid.realm&redirect_uri=storagerelay%3A%2F%2Fhttp%2Fconcord-consortium.github.io%3Fid%3Dauth892717&client_id=107140815081-p1so3nbhgvbeio1imeigd8sf1ve7l6tj.apps.googleusercontent.com&ss_domain=http%3A%2F%2Fconcord-consortium.github.io&gsiwebsdk=shim&o2v=1&as=RsVkg4YHV_NwB2SkafuS3g&flowName=GeneralOAuthFlow
-        cy.get('.button').contains('Login to Google').click();
+        cy.get('.button').contains('Sign in with Google').click();
     }
 
     getModalDialogTitle(){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.2.10",
+      "version": "2.2.11",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concord-consortium/cloud-file-manager.git"

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -143,7 +143,7 @@
 
   "~ALERT.NO_PROVIDER": "Could not open the specified document because an appropriate provider is not available.",
 
-  "~GOOGLE_DRIVE.LOGIN_BUTTON_LABEL": "Login to Google",
+  "~GOOGLE_DRIVE.LOGIN_BUTTON_LABEL": "Sign in with Google",
   "~GOOGLE_DRIVE.CONNECTING_MESSAGE": "Connecting to Google...",
   "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
   "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -143,7 +143,7 @@
 
   "~ALERT.NO_PROVIDER": "Could not open the specified document because an appropriate provider is not available.",
 
-  "~GOOGLE_DRIVE.LOGIN_BUTTON_LABEL": "Login to Google",
+  "~GOOGLE_DRIVE.LOGIN_BUTTON_LABEL": "Sign in with Google",
   "~GOOGLE_DRIVE.CONNECTING_MESSAGE": "Connecting to Google...",
   "~GOOGLE_DRIVE.ERROR_CONNECTING_MESSAGE": "Error connecting to Google!",
   "~GOOGLE_DRIVE.ERROR_MISSING_APIKEY": "Missing required apiKey in googleDrive provider options",


### PR DESCRIPTION
## Summary

Fixes [CFM-16](https://concord-consortium.atlassian.net/browse/CFM-16). Updates the Google sign-in button label from "Login to Google" to "Sign in with Google" via the proper source file (`en-US-master.json`), which the generated `en-US.json` is regenerated from.

## Background

[CODAP-1193](https://concord-consortium.atlassian.net/browse/CODAP-1193) (commit `3331d60`) intended to update the label, but only edited `en-US.json` — a generated file. `bin/strings-pull-project.sh:49-51` regenerates `en-US.json` from `en-US-master.json` (the POEditor source) on every `strings:pull`. Since `en-US-master.json` was never updated, the change was destined to be clobbered.

That's exactly what happened on v2.2.x during [CODAP-1216](https://concord-consortium.atlassian.net/browse/CODAP-1216) (#424), which ran `strings:pull` to bundle French and Dutch translations. The pull silently restored "Login to Google" in `en-US.json`. The same revert is currently propagating to master via #426.

"Login to Google" is also grammatically wrong — "Login" is a noun. "Sign in with Google" matches Google's branding guidelines.

## Changes

- `en-US-master.json` updated to "Sign in with Google" (the source of truth)
- `en-US.json` regenerated from the source via `npm run strings:pull`
- POEditor source pushed via `npm run strings:push`
- Non-English locale files unchanged — translators will see the new English source in POEditor and update over time
- Version bumped to 2.2.11

## Publish plan after merge

`npm publish` (the `latest` tag stays on this 2.2.x line).

After release, this fix should be cherry-picked into #426 (`merge-2.2.x-into-master`) so it ships with 2.3.1 on the `v2.3` tag.

## Test plan

- [x] CI green (lint, build, 213/213 tests)
- [ ] Manual: confirm Google sign-in button reads "Sign in with Google"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CFM-16]: https://concord-consortium.atlassian.net/browse/CFM-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CODAP-1193]: https://concord-consortium.atlassian.net/browse/CODAP-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CODAP-1216]: https://concord-consortium.atlassian.net/browse/CODAP-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ