### PR TITLE
fix: lower attachment threshold so large saves succeed [CFM-18]

### DIFF
--- a/src/code/providers/interactive-api-provider.test.ts
+++ b/src/code/providers/interactive-api-provider.test.ts
@@ -730,6 +730,13 @@ describe('InteractiveApiProvider', () => {
     expect(shouldSaveAsAttachment(contentAtThreshold)).toBe(true)
     expect(shouldSaveAsAttachment(contentAboveThreshold)).toBe(true)
 
+    // CFM-18 / spec R6: the size check measures UTF-8 bytes, not UTF-16 code units.
+    // A run of multi-byte characters can stay below the threshold by String length
+    // yet exceed it - and Firestore's byte-based 1 MiB limit - once UTF-8 encoded.
+    const multiByteContent = "€".repeat(kDynamicAttachmentSizeThreshold / 2)  // "€" is 1 code unit, 3 UTF-8 bytes
+    expect(JSON.stringify(multiByteContent).length).toBeLessThan(kDynamicAttachmentSizeThreshold)
+    expect(shouldSaveAsAttachment(multiByteContent)).toBe(true)
+
     // with an explicit kAttachmentUrlParameter value attachments are always used
     setQueryParams(`interactiveApi=${kAttachmentUrlParameter}`)
     expect(shouldSaveAsAttachment(contentBelowThreshold)).toBe(true)

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -61,18 +61,18 @@ interface InteractiveApiProviderParams {
 // pass `interactiveApi=attachment` as url parameter to always save state as an attachment
 export const kAttachmentUrlParameter = "attachment"
 
-// Inline interactive state below this size is saved directly into the Firestore
-// answer document; above it, state is offloaded to an S3 attachment.
+// Interactive state at or above this size is offloaded to an S3 attachment;
+// smaller state is saved directly into the Firestore answer document.
 //
-// CFM-18: this was 480 KiB, justified as "can save it twice with room to spare in
-// the 1MB Firestore limit" (480 * 2 = 960 KB). That math was wrong. Activity Player
-// stores the interactive state twice in one answer doc (`answer` + `report_state`),
-// but it embeds each copy as an escaped JSON *string* inside a `report` wrapper
-// alongside `attachments` and other fields. Measured expansion is ~2.2 bytes of
-// Firestore document per char of interactive state, so a state near 480 KiB
-// produced a ~1.06 MB document that Firestore rejected.
-// 1,048,576 / 2.2 ≈ 476 KB is the hard ceiling; 400 KiB leaves margin for
-// variation in escaping density and wrapper overhead.
+// CFM-18: this was 480 KiB, justified as "can save it twice with room to spare
+// in the 1MB Firestore limit" (480 * 2 = 960 KiB). That math was wrong. Activity
+// Player stores the interactive state twice in one answer doc (`answer` +
+// `report_state`), but it embeds each copy as an escaped JSON *string* inside a
+// `report` wrapper alongside `attachments` and other fields. Measured expansion
+// is ~2.2 bytes of Firestore document per char of interactive state, so a state
+// near 480 KiB produced a ~1.06 MB document that Firestore rejected.
+// The 1 MiB (1,048,576 byte) limit / 2.2 ≈ 465 KiB is the hard ceiling;
+// 400 KiB leaves margin for escaping-density variation and wrapper overhead.
 export const kDynamicAttachmentSizeThreshold = 400 * 1024
 
 // in solidarity with legacy DocumentStore implementation and S3 sharing implementation

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -61,8 +61,19 @@ interface InteractiveApiProviderParams {
 // pass `interactiveApi=attachment` as url parameter to always save state as an attachment
 export const kAttachmentUrlParameter = "attachment"
 
-// can save it twice with room to spare in 1MB Firestore limit
-export const kDynamicAttachmentSizeThreshold = 480 * 1024
+// Inline interactive state below this size is saved directly into the Firestore
+// answer document; above it, state is offloaded to an S3 attachment.
+//
+// CFM-18: this was 480 KiB, justified as "can save it twice with room to spare in
+// the 1MB Firestore limit" (480 * 2 = 960 KB). That math was wrong. Activity Player
+// stores the interactive state twice in one answer doc (`answer` + `report_state`),
+// but it embeds each copy as an escaped JSON *string* inside a `report` wrapper
+// alongside `attachments` and other fields. Measured expansion is ~2.2 bytes of
+// Firestore document per char of interactive state, so a state near 480 KiB
+// produced a ~1.06 MB document that Firestore rejected.
+// 1,048,576 / 2.2 ≈ 476 KB is the hard ceiling; 400 KiB leaves margin for
+// variation in escaping density and wrapper overhead.
+export const kDynamicAttachmentSizeThreshold = 400 * 1024
 
 // in solidarity with legacy DocumentStore implementation and S3 sharing implementation
 export const kLegacyAttachmentFilename = "file.json"

--- a/src/code/providers/interactive-api-provider.ts
+++ b/src/code/providers/interactive-api-provider.ts
@@ -20,7 +20,11 @@ export const shouldSaveAsAttachment = (content: any) => {
     return true
   }
 
-  const aboveDynamicThreshold = JSON.stringify(content).length >= kDynamicAttachmentSizeThreshold
+  // Measure the UTF-8 byte length, not String.prototype.length: the latter counts
+  // UTF-16 code units and undercounts non-ASCII content, whereas Firestore's 1 MiB
+  // document limit — and kDynamicAttachmentSizeThreshold — are byte-based. (spec R6)
+  const serializedBytes = new TextEncoder().encode(JSON.stringify(content)).byteLength
+  const aboveDynamicThreshold = serializedBytes >= kDynamicAttachmentSizeThreshold
   if (aboveDynamicThreshold) {
     return true
   }

--- a/src/test/setupTests.ts
+++ b/src/test/setupTests.ts
@@ -16,6 +16,10 @@ g.createReactClassFactory = (classDef: any) => g.createReactFactory(g.createReac
 // providers use window.alert() (which isn't implemented in JSDom) to signal unimplemented methods
 window.alert = jest.fn(msg => console.error(msg))
 
+// TextEncoder is a standard browser global but isn't exposed by the jsdom test
+// environment; polyfill it from Node's util module so code under test can use it.
+g.TextEncoder = g.TextEncoder ?? require('util').TextEncoder
+
 declare global {
   function jestSpyConsole(method: ConsoleMethod, fn: JestSpyConsoleFn,
                           options?: IJestSpyConsoleOptions): Promise<jest.SpyInstance>


### PR DESCRIPTION
Large interactive states near 480 KiB produced ~1.06 MB Firestore answer documents that exceeded the 1 MB limit and failed to save. Activity Player stores the state twice as escaped JSON strings inside a report wrapper, expanding it to ~2.2 bytes of document per character of state. Lower kDynamicAttachmentSizeThreshold from 480 KiB to 400 KiB so oversized states are offloaded to an S3 attachment before the document grows too large.

Additionally, `shouldSaveAsAttachment()` now measures the serialized state's UTF-8 byte length (via `TextEncoder`) instead of `JSON.stringify(content).length`, which counts UTF-16 code units. The previous check undercounted non-ASCII content relative to Firestore's byte-based 1 MB limit, so multi-byte states could exceed the limit even while reported as "below" the threshold. A regression test covers this case, and a jsdom test-environment shim provides `TextEncoder` for tests.

---

See here for investigation: https://gist.github.com/dougmartin/54bafa93a9dc5185a609da8b5b63b4ac