### PR TITLE
CODAP-1341: suppress focus outline on CFM menu list container

### DIFF
--- a/src/style/components/dropdown-menu.styl
+++ b/src/style/components/dropdown-menu.styl
@@ -83,6 +83,13 @@
     &.separator
       background none
 
+// React Aria gives the menu list container programmatic focus when a menu
+// opens; it is never a meaningful keyboard focus target (keyboard users
+// navigate the menu items, which carry their own :focus-visible outline),
+// so suppress the browser's default focus outline on the container itself.
+.menu-list-container:focus
+  outline none
+
 .sub-menu
   position absolute;
   left 130px !important;


### PR DESCRIPTION
## Summary

Suppresses the browser's default focus outline on the CFM menu list container (`.menu-list-container`).

React Aria gives `.menu-list-container` programmatic keyboard focus when a menu (File, Settings, Help, …) opens. The browser's `:focus-visible` heuristic resolves that focus inconsistently, and when it resolves true the browser draws its default focus outline around the **whole menu container**. The container is never a meaningful keyboard focus target — keyboard users navigate the menu *items*, which carry their own `:focus-visible` outline — so this adds a rule to remove the outline on the container itself.

## Relationship to CODAP PR #2585

[CODAP PR #2585](https://github.com/concord-consortium/codap/pull/2585) fixes two CFM-menu symptoms that share a root cause:

- **Missing drop shadow** — caused by a CODAP-specific global box-shadow reset (`*:focus:not(:focus-visible) { box-shadow: none !important }`). That rule lives only in CODAP, so that fix correctly belongs in CODAP.
- **Stray focus outline** — *not* caused by CODAP's reset (which only touches `box-shadow`, never `outline`). It is the browser's default UA focus ring on the programmatically-focused container, and it appears in **any** host app embedding the CFM.

This PR addresses the second symptom in the CFM, where it belongs. CFM previously had no `outline` rule on `.menu-list-container` at all. Once this ships, the matching `.menu-list-container:focus { outline: none }` rule in CODAP PR #2585 becomes redundant (the box-shadow exclusion still needs to stay in CODAP).

## Changes

`src/style/components/dropdown-menu.styl`:

- Add a top-level `.menu-list-container:focus { outline: none }` rule, so it covers both the main menu and submenu containers.

## Testing

CSS-only change; production build compiles and the rule is present in the emitted `app.css`. No automated test added (consistent with CODAP PR #2585).

Relates to CODAP-1341. This PR targets `v2.2.x`; it can be cherry-picked to `master` later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
