### PR TITLE
Release v2.2.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/cloud-file-manager",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/cloud-file-manager",
-      "version": "2.2.11",
+      "version": "2.2.12",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@concord-consortium/cloud-file-manager",
   "description": "Wrapper for providing file management for web applications",
   "author": "The Concord Consortium",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concord-consortium/cloud-file-manager.git"


### PR DESCRIPTION
Release **v2.2.12** — bumps the version `2.2.11` → `2.2.12` in `package.json` and `package-lock.json`.

## Bug fixes in this release

- **#429 — CFM-18: lower attachment threshold so large saves succeed.**
  Large interactive states near 480 KiB produced ~1.06 MB Firestore answer
  documents that exceeded the 1 MB limit and failed to save. Lowers the
  dynamic attachment size threshold so oversized states are offloaded to an
  S3 attachment, and switches the size check to UTF-8 byte counting so
  multi-byte content is measured correctly. (Backport of #428.)

- **#430 — CODAP-1341: suppress focus outline on CFM menu list container.**
  A stray browser focus outline could appear around the whole CFM menu
  (File, Settings, Help, …) when it was opened, because React Aria gives the
  menu list container programmatic focus. Adds a CSS rule so the container —
  never a meaningful keyboard focus target — shows no focus outline; keyboard
  users still navigate the menu items, which keep their own focus styling.

Both fixes are already merged into `v2.2.x`; this PR only adds the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
