### PR TITLE
Switch S3 deployment to OIDC authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
     needs:
       - jest
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -29,12 +33,14 @@ jobs:
           node-version: '20'
       - name: Install Dependencies
         run: npm ci
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/cloud-file-manager
+          aws-region: us-east-1
       - uses: concord-consortium/s3-deploy-action@v1
         with:
           bucket: models-resources
           prefix: ${{ github.event.repository.name }} # cloud-file-manager
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           deployRunUrl: https://models-resources.concord.org/cloud-file-manager/__deployPath__/examples/
           # Parameters to GHActions have to be strings, so a regular yaml array cannot

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -1,4 +1,5 @@
 name: Release Staging
+run-name: Release Staging ${{ github.event.inputs.version }}
 on:
   workflow_dispatch:
     inputs:
@@ -11,13 +12,15 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/cloud-file-manager
+          aws-region: us-east-1
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/staging/
           --recursive
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -1,4 +1,5 @@
 name: Release Production
+run-name: Release Production ${{ github.event.inputs.version }}
 on:
   workflow_dispatch:
     inputs:
@@ -11,13 +12,15 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/cloud-file-manager
+          aws-region: us-east-1
       - run: >
           aws s3 cp
-          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}
+          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/
           --recursive
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -1,0 +1,21 @@
+# Deployment
+
+S3 deployment is handled by GitHub Actions. Pushes are deployed under
+`models-resources/cloud-file-manager/` — branch builds to `branch/<name>/...` and tag
+builds to `version/<tag>/...` — by the `s3-deploy` job in
+[`ci.yml`](../.github/workflows/ci.yml). A version is promoted by recursively copying its
+`version/<version>/` folder to `staging/` by
+[`release-staging.yml`](../.github/workflows/release-staging.yml), and to the top level by
+[`release_production.yml`](../.github/workflows/release_production.yml), each via `workflow_dispatch`.
+
+## AWS Access
+
+The GitHub Actions workflows in this project are allowed to update files in S3 using OIDC.
+An IAM role has been created in AWS with a trust policy that allows GitHub Actions in
+this specific repository to assume this IAM role. The IAM role has a `RepoName` tag
+and a managed policy that uses this tag to give the role permission to update files under
+`s3://models-resources/cloud-file-manager/`.
+
+See
+[deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md)
+for how the AWS side is set up.

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,8 @@ To update all clients that are using the in-development version of CFM, in the C
 
 ## Deployment
 
+S3 deployment uses OIDC for AWS authentication — see [deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md) for how the AWS side is set up, and [doc/deploy.md](doc/deploy.md) for how deploys work in this repo.
+
 Deployments are based on the contents of the /dist folder and are built automatically by GitHub Actions for each branch and tag pushed to GitHub.
 
 Branches are deployed to `https://cloud-file-manager.concord.org/branch/<name>/`.


### PR DESCRIPTION
[DEV-163](https://concord-consortium.atlassian.net/browse/DEV-163)

Replace static AWS access-key secrets with OIDC role assumption in the S3 deploy workflows, per DEV-163. `ci.yml` s3-deploy plus `release-staging.yml` and `release_production.yml` (run-name added to both); `doc/deploy.md` + `README` reference added.

[DEV-163]: https://concord-consortium.atlassian.net/browse/DEV-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ